### PR TITLE
Add Worker static asset config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(bun *)",
-      "Bash(bunx *)",
-      "Bash(git *)"
-    ]
+    "allow": ["Bash(bun *)", "Bash(bunx *)", "Bash(git *)"]
   },
   "enabledPlugins": {
     "claude-md-management@claude-plugins-official": true,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,5 @@
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    return env.ASSETS.fetch(req);
+  },
+} satisfies ExportedHandler<Env>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleDetection": "force",
     "jsx": "react-jsx",
     "allowJs": true,
-    "types": ["bun"],
+    "types": ["bun", "./worker-configuration.d.ts"],
 
     // Bundler mode
     "moduleResolution": "bundler",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,16 @@
+name = "personal-site"
+main = "src/worker.ts"
+compatibility_date = "2026-05-17"
+
+[assets]
+directory = "./dist"
+binding = "ASSETS"
+not_found_handling = "single-page-application"  # serves index.html for unknown paths → SPA routes work
+
+[vars]
+# env vars here later
+
+# When you add a Worker fetch handler (forms, API, OG images), uncomment:
+# [[routes]]
+# pattern = "moster.dev/api/*"
+# zone_name = "moster.dev"


### PR DESCRIPTION
Adds the Cloudflare Workers configuration for Static Assets with SPA fallback. Adds the pass-through Worker entrypoint that delegates to the ASSETS binding. Updates TypeScript config to include generated Wrangler environment types and keeps Claude settings formatted.