### PR TITLE
Implement Task 03 (theming & global styles)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,6 +32,11 @@
       "trailingCommas": "all"
     }
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "assist": {
     "enabled": true,
     "actions": {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,51 @@
+@import "tailwindcss";
+
+:root {
+  --bg: #fafafa;
+  --fg: #0a0a0a;
+  --muted: #6b6b6b;
+  --accent: #1a1410;
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0a0a0a;
+    --fg: #fafafa;
+    --muted: #a3a3a3;
+    --accent: #faf5ec;
+  }
+}
+
+@theme {
+  --color-bg: var(--bg);
+  --color-fg: var(--fg);
+  --color-muted: var(--muted);
+  --color-accent: var(--accent);
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-sans);
+}
+
+article,
+.prose {
+  max-width: 65ch;
+  line-height: 1.7;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+}


### PR DESCRIPTION
## Summary
- Adds `src/styles/globals.css`: Tailwind v4 entry, the six §FR-1.3.2 tokens on `:root` (`#fafafa`/`#0a0a0a` swap, muted ~60% luminance, warm accent `#1a1410` light / `#faf5ec` dark), `prefers-color-scheme` dark override, `@theme` mapping so `bg-bg`/`text-fg`/`text-muted`/`text-accent`/`font-sans`/`font-serif` utilities exist and the dark swap flows through them without `dark:` variants, plus body + prose (65ch / 1.7) + mono base rules. Resolves the two open questions in `features/theming.md`.
- Enables `css.parser.tailwindDirectives` in `biome.json` so Biome's CSS parser accepts `@theme` (Task 01 installed both Biome and Tailwind v4 but didn't wire them together — without this, `bun run check` fails on every Tailwind v4 stylesheet).

## Test plan
- [x] `bun run check` (wrangler types + biome + tsc) passes clean.
- [ ] Manual rendering verification deferred to Task 04 (once `index.html` links the stylesheet) and Task 07 (Playwright dark-mode assertion), per the task plan.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>