### PR TITLE
Generate Wrangler types during prepare

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "bun install && bunx wrangler types",
+    "setup": "bun install",
     "run": "bun run dev"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "bun test",
     "setup:browsers": "playwright install chromium",
     "check": "wrangler types && biome check && tsc --noEmit",
-    "prepare": "husky"
+    "prepare": "husky && wrangler types"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",


### PR DESCRIPTION
## Summary
- Move Wrangler type generation into the package prepare lifecycle.
- Simplify the Conductor setup script to rely on bun install running prepare.

## Verification
- Pre-commit hook ran bun run check during commit; it completed with the existing Biome warning in src/main.tsx.