### PR TITLE
Add smoke and Playwright test coverage

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  testMatch: "**/*.e2e.ts",
+  fullyParallel: true,
+  use: {
+    baseURL: "http://localhost:3000",
+  },
+  webServer: {
+    command: "bun run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/e2e/site.e2e.ts
+++ b/tests/e2e/site.e2e.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+test("home page loads with the React root attached", async ({ page }) => {
+  const response = await page.goto("/");
+  expect(response?.status()).toBe(200);
+  await expect(page.locator("#root")).toBeAttached();
+});
+
+test("hero copy renders verbatim", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByText("It's my pleasure to invite you into my portfolio."),
+  ).toBeVisible();
+});
+
+test("hero exposes the three canonical social links", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.locator("a[href='https://github.com/jlvmoster']"),
+  ).toBeVisible();
+  await expect(
+    page.locator("a[href='https://instagram.com/jlvmoster']"),
+  ).toBeVisible();
+  await expect(
+    page.locator("a[href='https://linkedin.com/in/jlvmoster']"),
+  ).toBeVisible();
+});
+
+test("dark mode swaps the body background via prefers-color-scheme", async ({
+  browser,
+}) => {
+  const readBodyBackground = async (colorScheme: "light" | "dark") => {
+    const context = await browser.newContext({ colorScheme });
+    const page = await context.newPage();
+    try {
+      await page.goto("/");
+      return await page
+        .locator("body")
+        .evaluate((el) => getComputedStyle(el).backgroundColor);
+    } finally {
+      await context.close();
+    }
+  };
+
+  const lightBg = await readBodyBackground("light");
+  const darkBg = await readBodyBackground("dark");
+
+  expect(lightBg).not.toBe(darkBg);
+});
+
+test("dev server serves the SPA shell for unknown paths", async ({ page }) => {
+  const response = await page.goto("/some-unknown-path");
+  expect(response?.status()).toBe(200);
+  await expect(page.locator("#root")).toBeAttached();
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { App } from "../src/App";
+
+test("App renders without throwing and contains the canonical hero copy + section IDs in order", () => {
+  const html = renderToStaticMarkup(createElement(App));
+  const text = html.replace(/&#x27;/g, "'");
+
+  expect(text).toContain("It's my pleasure to invite you into my portfolio.");
+
+  const order = ["hero", "writing", "about", "contact"].map((id) =>
+    html.indexOf(`id="${id}"`),
+  );
+  expect(order.every((i) => i >= 0)).toBe(true);
+  expect(order).toEqual([...order].sort((a, b) => a - b));
+
+  for (const url of [
+    "https://github.com/jlvmoster",
+    "https://instagram.com/jlvmoster",
+    "https://linkedin.com/in/jlvmoster",
+  ]) {
+    expect(html).toContain(url);
+  }
+});


### PR DESCRIPTION
Adds a Bun smoke test that server-renders the React app and verifies the canonical hero copy, section order, and social links. Adds Playwright Chromium configuration plus e2e coverage for page load, hero copy, social links, dark-mode background behavior, and dev-server SPA fallback routes. Verified locally with `bun test` and `bunx playwright test`.