### PR TITLE
Update project README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,23 +43,22 @@ test("hello world", () => {
 
 This repo is Jalo's personal website. **The authoritative requirements doc is `docs/specs/requirements.md` — read it before any non-trivial change.** It covers the deployment model, file layout, content sections, growth path, and the resolved decisions (domain, socials, hero copy, typography).
 
-Current state: `bun init --empty` skeleton + `@playwright/test` installed. No `src/` yet — the scaffold work implied by the requirements doc's acceptance criteria hasn't run.
+Current state: v1 complete. `src/` ships Hero / Writing / About / Contact / Nav components, `scripts/dev.ts` + `scripts/build.ts` drive the Bun HTML bundler, `wrangler.toml` + `src/worker.ts` handle Workers + Static Assets, and `.github/workflows/ci.yml` runs check + e2e on PR and deploys on push to `master`. See `README.md` for the user-facing summary.
 
 ## Commands
-These are the scripts the requirements doc defines. Items marked _(post-scaffold)_ don't exist yet — `package.json` has no `scripts` block until the scaffold step runs.
 
-| Purpose | Command | Status |
-|---|---|---|
-| Install deps | `bun install` | works |
-| Install browser deps | `bun run setup:browsers` | post-scaffold (`playwright install chromium`) |
-| Unit tests | `bun test` | works (no specs yet) |
-| Dev server | `bun run dev` | post-scaffold (`scripts/dev.ts` + `Bun.serve` + HMR) |
-| Production build | `bun run build` | post-scaffold (`scripts/build.ts` → `dist/`) |
-| Local Workers runtime | `bun run preview` | post-scaffold (`wrangler dev`) |
-| Deploy (break-glass only) | `bun run deploy` | post-scaffold (`wrangler deploy`); production deploys go through GitHub Actions on push to `master` — see `docs/specs/features/ci-cd.md` |
-| Type + lint check | `bun run check` | post-scaffold (`wrangler types && biome check && tsc --noEmit`) |
-| Regenerate Worker types | `bunx wrangler types` | works after `wrangler.toml` exists |
-| E2E (browser) | `bunx playwright test` | works after `playwright.config.ts` exists |
+| Purpose | Command |
+|---|---|
+| Install deps (also runs `husky` + `wrangler types` via `prepare`) | `bun install` |
+| Install browser deps | `bun run setup:browsers` (`playwright install chromium`) |
+| Dev server (HMR) | `bun run dev` (`scripts/dev.ts` + `Bun.serve`) |
+| Production build | `bun run build` (`scripts/build.ts` → `dist/`) |
+| Local Workers runtime | `bun run preview` (`wrangler dev`) |
+| Deploy (break-glass only) | `bun run deploy` — prod deploys run from GitHub Actions on push to `master`, see `docs/specs/features/ci-cd.md` |
+| Type + lint check | `bun run check` (`wrangler types && biome check && tsc --noEmit`) |
+| Regenerate Worker types | `bunx wrangler types` |
+| Unit tests | `bun test` |
+| E2E (browser) | `bunx playwright test` against `bun run dev` |
 
 ## Key files
 - `docs/specs/requirements.md` — authoritative requirements doc (read first).
@@ -70,9 +69,11 @@ These are the scripts the requirements doc defines. Items marked _(post-scaffold
 - `.claude/settings.json` — enabled plugins and Bash permission allowlist.
 - `.github/CODEOWNERS` — requires `@jlvmoster` review on every PR.
 - `.github/dependabot.yml` — weekly grouped Bun-ecosystem updates (open-PR limit 5); source of `Bump …` PRs like #3.
-- `.github/workflows/ci.yml` — _(post-scaffold)_ single workflow with `check` (PRs + pushes) and `deploy` (push to `master`, needs `check`); canonical YAML in architecture §8.1.
-- `wrangler.toml`, `src/worker.ts` — _(post-scaffold)_ Cloudflare Workers + Static Assets config and pass-through fetch handler.
+- `.github/workflows/ci.yml` — single workflow with `check` (PRs + pushes) and `deploy` (push to `master`, needs `check`); canonical YAML in architecture §8.1.
+- `wrangler.toml`, `src/worker.ts` — Cloudflare Workers + Static Assets config and pass-through fetch handler.
 - `worker-configuration.d.ts` — _(generated, gitignored)_ Worker runtime types, refreshed by `bunx wrangler types`.
+- `README.md` — user-facing project summary (stack, quickstart, deploy flow); keep in sync when the project layout changes.
+- `.husky/` — pre-commit hook installed automatically by `prepare` on `bun install`.
 
 ## Docs conventions
 - **Three layers under `docs/specs/`:** `requirements.md` is *what must be true* (every requirement has an ID like `§FR-1.2.1.a`); `architecture.md` is *why + canonical code shapes*; `features/*.md` are per-feature implementation specs that cite requirements via those §IDs.
@@ -97,9 +98,8 @@ These are the scripts the requirements doc defines. Items marked _(post-scaffold
 
 ## Testing
 - **Unit / integration:** `bun test`. Files: `*.test.ts` colocated with source or under `tests/`.
-- **Browser smoke (E2E):** `@playwright/test` is installed, but each fresh machine or CI worker must run `bun run setup:browsers` (`playwright install chromium`) before `bunx playwright test`. Place specs in `tests/e2e/*.spec.ts` and run them against `bun run dev`.
+- **Browser smoke (E2E):** `bunx playwright test` runs specs under `tests/e2e/` against `bun run dev` (wired via `playwright.config.ts`). Each fresh machine or CI worker must run `bun run setup:browsers` (`playwright install chromium`) once before the first run.
   - Keep specs thin: page loads, hero copy renders, all three social links resolve, dark mode applies via `prefers-color-scheme`. Don't snapshot the whole DOM.
-  - The runner is installed but unwired — `bunx playwright test` will fail with "no tests found" until `playwright.config.ts` and a spec under `tests/e2e/` exist.
 - **Interactive verification during a task:** use the `mcp__plugin_playwright_playwright__*` MCP tools to drive a browser ad-hoc rather than writing throwaway specs. Per the global rule, UI changes must be exercised in a browser before being reported as complete.
 
 ## Agents and skills

--- a/README.md
+++ b/README.md
@@ -1,15 +1,92 @@
-# website
+# moster.dev
 
-To install dependencies:
+Jalo Moster's personal website — a single-page React SPA deployed to Cloudflare Workers with Static Assets.
+
+**Status:** v1 complete. Hero, Writing (empty state), About, and Contact sections live; light/dark theming via `prefers-color-scheme`; smoke + Playwright E2E coverage; CI and production deploys on push to `master`.
+
+## Stack
+
+- **Runtime / tooling:** [Bun](https://bun.com) — package manager, dev server, HTML bundler, test runner.
+- **UI:** React 19, Tailwind v4 (via `bun-plugin-tailwind`), system font stacks only.
+- **Hosting:** Cloudflare Workers + Static Assets (not Pages) on `moster.dev`.
+- **Lint / format:** Biome. **Types:** TypeScript strict mode + generated Worker types.
+- **Testing:** `bun test` for units, `@playwright/test` for browser E2E.
+- **CI/CD:** GitHub Actions — `check` on every PR/push, `deploy` on push to `master` via `cloudflare/wrangler-action@v3`.
+
+No Vite, webpack, esbuild, Next.js, or component libraries — the Bun HTML bundler is the entire build pipeline.
+
+## Quickstart
 
 ```bash
 bun install
+bun run setup:browsers   # installs Playwright's Chromium (once per machine)
+bun run dev              # http://localhost:3000 with HMR
 ```
 
-To run:
+## Scripts
 
-```bash
-bun run index.ts
+| Command | What it does |
+|---|---|
+| `bun run dev` | Local dev server with HMR (`scripts/dev.ts` → `Bun.serve`). |
+| `bun run build` | Bundles `src/index.html` to `dist/` and copies `public/` over (`scripts/build.ts`). |
+| `bun run preview` | Production-equivalent Workers runtime via `wrangler dev`. |
+| `bun run deploy` | `wrangler deploy` — break-glass only; prod deploys run from GitHub Actions. |
+| `bun run check` | `wrangler types && biome check && tsc --noEmit`. |
+| `bun test` | Unit / integration tests. |
+| `bunx playwright test` | Browser E2E specs under `tests/e2e/`. |
+| `bun run setup:browsers` | `playwright install chromium`. |
+
+## Project layout
+
+```
+src/
+  index.html            # bundler entry — <script src="./main.tsx">
+  main.tsx              # React root
+  App.tsx               # composes Nav + sections
+  components/           # Nav, Hero, Writing, About, Contact
+  styles/globals.css    # Tailwind v4 + CSS variables (--bg, --fg, --muted, --accent, ...)
+  worker.ts             # pass-through fetch → env.ASSETS.fetch(req)
+scripts/
+  dev.ts                # Bun.serve dev loop with HMR
+  build.ts              # Bun.build + public/ copy
+tests/
+  smoke.test.ts         # bun test
+  e2e/site.e2e.ts       # Playwright
+public/                 # static assets outside the bundler graph (favicon, robots.txt)
+docs/
+  specs/                # requirements, architecture, per-feature specs
+  tasks/                # numbered implementation playbook (01–09)
+wrangler.toml           # Workers + Static Assets config
+worker-configuration.d.ts  # generated, gitignored
 ```
 
-This project was created using `bun init` in bun v1.3.14. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+## Theming
+
+Light and dark schemes are driven by `prefers-color-scheme` — no toggle. Design tokens are exposed as CSS variables in `src/styles/globals.css`: `--bg`, `--fg`, `--muted`, `--accent`, `--font-sans`, `--font-serif`. Typography uses system font stacks only (no hosted fonts).
+
+## Testing
+
+- **Unit:** `bun test` — specs colocated with source or under `tests/`.
+- **E2E:** `bunx playwright test` against `bun run dev`. Coverage: page loads, hero copy renders verbatim, all three social links resolve, dark mode applies via `prefers-color-scheme`.
+- A fresh machine can recreate the full test environment with `bun install && bun run setup:browsers`.
+
+## Deployment
+
+Production deploys run automatically on push to `master`:
+
+1. `check` job: `bun install --frozen-lockfile`, `setup:browsers`, `check`, `build`, `bun test`, `bunx playwright test`.
+2. `deploy` job (depends on `check`): builds and ships `dist/` via `cloudflare/wrangler-action@v3`.
+
+Cloudflare credentials live as GitHub Actions secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and are never committed. `bun run deploy` from a developer machine is supported as a break-glass path but is not the source of truth.
+
+## Docs
+
+- [`docs/specs/requirements.md`](./docs/specs/requirements.md) — authoritative requirements (every requirement has an ID like `§FR-1.2.1.a`).
+- [`docs/specs/architecture.md`](./docs/specs/architecture.md) — rationale and canonical code shapes.
+- [`docs/specs/features/*.md`](./docs/specs/features/) — per-feature implementation specs.
+- [`docs/tasks/README.md`](./docs/tasks/README.md) — nine-step implementation playbook.
+- [`CLAUDE.md`](./CLAUDE.md) — conventions and hard rules for agent-driven work in this repo.
+
+## Growth path
+
+Designed-in but not built in v1: MDX blog under `src/content/` with a route per file, `/api/contact` form handler in `src/worker.ts`, `/api/og` image generation via `workers-og`, Cloudflare Web Analytics, and edge data via Workers KV/D1/R2. See [`docs/specs/requirements.md` §3](./docs/specs/requirements.md).


### PR DESCRIPTION
## Summary
- Replaces the default Bun README with project-specific documentation for moster.dev.
- Documents the stack, setup commands, scripts, layout, testing, deployment, docs, and growth path.

## Testing
- Not run; documentation-only change.