### PR TITLE
Add acceptance verification coverage

### DIFF
--- a/.claude/skills/changelog-generator/SKILL.md
+++ b/.claude/skills/changelog-generator/SKILL.md
@@ -1,46 +1,41 @@
 ---
 name: changelog-generator
-description: Generate user-facing changelogs from git commits for moster.dev — scans history, groups changes by intent (features, improvements, fixes, breaking changes), rewrites technical commit messages into clear reader-friendly entries, and outputs polished Markdown. Use this skill whenever the user asks for a changelog, release notes, "what's new", "what shipped", site updates, a weekly/monthly digest, or wants to publish a list of recent changes — even if they don't say the word "changelog".
+description: Use when the user asks for a changelog, release notes, "what's new", "what shipped", site updates, a weekly or monthly digest, or any curated reader-facing list of recent moster.dev changes — even if they don't say "changelog". Skip only when the user explicitly wants raw `git log` output.
 ---
 
 # Changelog Generator
 
 Turn git commit history on moster.dev into a clean, reader-friendly changelog. The audience is humans visiting the site or reading an update post — not other developers.
 
-## When this triggers
-Use this skill for any phrasing along the lines of:
-- "make a changelog" / "generate release notes" / "draft an update post"
-- "summarize what shipped last week" / "what's new since v1.2"
-- "write a 'what changed' section" / "weekly update" / "site updates"
-- Anything that asks for a curated, human-readable list of recent changes
+## Workflow
 
-Skip this skill only if the user clearly wants raw `git log` output instead of a curated summary.
-
-## What it does
-1. **Pick a range.** Default is the most recent semver tag (`git describe --tags --abbrev=0`) → `HEAD`. Falls back to "last 7 days" (`git log --since=7.days`) when no tag exists. The user can override with a date range, version, or commit range.
-2. **Read the commits.** Run `git log <range> --pretty=format:"%H%x09%s%x09%b%x1e" --no-merges` and parse the resulting records. Skip merge commits.
-3. **Categorize.** Map each commit to one of: **New**, **Improvements**, **Fixes**, **Breaking**, or **Internal** (filtered out by default). See "Categorization" below.
-4. **Rewrite for readers.** Convert `feat(blog): add MDX support` → `Posts now support rich formatting via MDX.` Keep entries short, declarative, present-tense, and benefit-oriented.
-5. **Render Markdown.** Use the template below. Save to the path the user specified, or `CHANGELOG.md` at repo root by default. If the user just wants to copy/paste, print to stdout instead of writing.
+1. **Pick a range.** Default to most recent semver tag (`git describe --tags --abbrev=0`) → `HEAD`. Fall back to past 7 days (`git log --since=7.days`) when no tag exists. Ask the user if the range is ambiguous — one question is cheaper than rewriting.
+2. **Read commits.** `git log <range> --pretty=format:"%H%x09%s%x09%b%x1e" --no-merges`. Skip merge commits.
+3. **Categorize.** Map each commit to **New**, **Improvements**, **Fixes**, **Breaking**, or **Internal** (filtered out). See the table below.
+4. **Rewrite for readers.** Convert `feat(blog): add MDX support` → `Posts now support rich formatting via MDX.` Short, declarative, present-tense, benefit-oriented.
+5. **Render Markdown** using the template below.
+6. **Show before saving.** Ask before writing to disk. When saving, prepend to existing `CHANGELOG.md` rather than overwriting.
 
 ## Categorization
-Match each commit by inspecting both the prefix and the message body. Multiple signals can apply — pick the highest-priority bucket per commit.
+
+Inspect both the commit prefix and the body. Multiple signals can apply — pick the highest-priority bucket.
 
 | Bucket | Triggers | Examples |
 |---|---|---|
-| **Breaking** | `BREAKING CHANGE:` in body, `feat!:` / `fix!:` prefix, message mentions removed/renamed user-visible behavior | "Drop legacy `/blog` redirect", "Rename `/about` → `/me`" |
+| **Breaking** | `BREAKING CHANGE:` in body, `feat!:` / `fix!:` prefix, removed/renamed user-visible behavior | "Drop legacy `/blog` redirect", "Rename `/about` → `/me`" |
 | **New** | `feat:`, `feat(scope):` | New page, new section, new visible feature |
-| **Improvements** | `perf:`, `style:` (visual style only), `a11y:`, copy/typography tweaks, design polish | Faster image loading, better dark mode contrast, refreshed hero |
+| **Improvements** | `perf:`, visual `style:`, `a11y:`, copy/typography tweaks, design polish | Faster image loading, better dark mode contrast, refreshed hero |
 | **Fixes** | `fix:`, `fix(scope):` | Bug fixes the reader could have hit |
-| **Internal** *(excluded)* | `chore:`, `refactor:`, `test:`, `docs:`, `build:`, `ci:`, dependency bumps (`bun add`, `bun update`), commit subject starts with `[skip changelog]` | Tooling, lockfile updates, README edits |
+| **Internal** *(excluded)* | `chore:`, `refactor:`, `test:`, `docs:`, `build:`, `ci:`, dependency bumps, `[skip changelog]` in subject | Tooling, lockfile updates, README edits |
 
-Edge cases:
-- A `chore:` that's actually user-visible (e.g., "chore: rewrite hero copy") belongs in **Improvements** — judge by impact, not by prefix.
-- If a commit is ambiguous, prefer the bucket the reader cares about more (a fix that introduces a new affordance → **New**).
-- Drop entries that turn out to be too small to be interesting in user terms (e.g., a typo fix in a deleted draft).
+**Edge cases:**
+- A `chore:` that's actually user-visible (e.g., "chore: rewrite hero copy") belongs in **Improvements** — judge by impact, not prefix.
+- Ambiguous commits go in the bucket the reader cares about more (a fix that adds a new affordance → **New**).
+- Drop entries too small to matter to readers (a typo fix in a deleted draft).
 
 ## Output template
-moster.dev is a minimal-aesthetic site. **Default to no emojis** — use plain headings. Only add emoji headers if the user asks for them or asks for the "punchier" style from the source template. Each entry is one or two sentences; lead with the benefit, follow with the detail.
+
+moster.dev is a minimal-aesthetic site. **Default to no emojis** — plain headings only. Add emoji only if the user requests it. Each entry is one or two sentences; lead with the benefit, follow with the detail.
 
 ```markdown
 # Updates — <date or version>
@@ -58,60 +53,35 @@ moster.dev is a minimal-aesthetic site. **Default to no emojis** — use plain h
 - <Sentence describing the change and what readers need to do.>
 ```
 
-Drop any section that has zero entries. If the entire range produces no user-facing changes, return a single line: `No user-facing changes in this range.` — don't pad it.
+Drop empty sections. If the entire range produces no user-facing changes, return one line: `No user-facing changes in this range.` — don't pad it.
 
-## Workflow
-1. Confirm the range with the user if it's unclear ("since last tag" vs. "past week" vs. a specific date/commit). Don't guess if the user said something vague — one question is cheaper than rewriting.
-2. Run the `git log` command. If the repo has no tags and the user didn't specify a range, default to the past 7 days.
-3. Pull the commits into memory, classify each one, draft the rewrite for the user-facing buckets, and discard `Internal`.
-4. Render the Markdown, then show the result. Ask before writing to disk — overwriting `CHANGELOG.md` is destructive.
-5. When saving, prepend the new section to an existing `CHANGELOG.md` rather than overwriting it. Keep older sections intact.
+## Style rules
 
-## Style rules for rewrites
 - **Present tense, active voice.** "Posts load 2x faster." not "We've improved post loading speed."
-- **Reader's perspective.** Talk about what the site does, not what you did. "Dark mode now follows your OS setting." beats "Implemented prefers-color-scheme."
-- **No code/file references in the entry text.** `src/components/Hero.tsx` doesn't belong in a reader-facing changelog.
-- **No commit hashes** unless the user explicitly asks. Hashes belong in `git log`, not in a changelog.
-- **Preserve "my pleasure".** If you find yourself describing changes to the hero copy, never paraphrase the canonical hero line away (see `CLAUDE.md`).
-- **One thought per bullet.** If a commit did two things, split it.
+- **Reader's perspective.** What the site does, not what you did. "Dark mode now follows your OS setting." beats "Implemented prefers-color-scheme."
+- **No code or file references** in entry text. `src/components/Hero.tsx` doesn't belong in a changelog.
+- **No commit hashes** unless explicitly requested.
+- **Preserve "my pleasure".** Never paraphrase the canonical hero line (see CLAUDE.md).
+- **One thought per bullet.** Split a commit that did two things.
 
 ## Examples
 
-**Input commit:**
-```
-feat(blog): add MDX support with frontmatter parsing and code block syntax highlighting
-```
-**Reader entry (New):**
-- **Rich post formatting.** Posts now support code blocks, callouts, and inline formatting.
+| Input commit | Bucket | Reader entry |
+|---|---|---|
+| `feat(blog): add MDX support with frontmatter parsing and code block syntax highlighting` | New | **Rich post formatting.** Posts now support code blocks, callouts, and inline formatting. |
+| `perf: lazy-load hero image and inline critical CSS` | Improvements | The home page paints noticeably faster on the first visit. |
+| `fix: prevent dark-mode flash on initial paint` | Fixes | Dark mode no longer flashes white when the page first loads. |
+| `chore(deps): bun update typescript to 5.9.4` | Internal *(excluded)* | — |
 
----
+## Common mistakes
 
-**Input commit:**
-```
-perf: lazy-load hero image and inline critical CSS
-```
-**Reader entry (Improvements):**
-- The home page paints noticeably faster on the first visit.
-
----
-
-**Input commit:**
-```
-fix: prevent dark-mode flash on initial paint
-```
-**Reader entry (Fixes):**
-- Dark mode no longer flashes white when the page first loads.
-
----
-
-**Input commit (filtered):**
-```
-chore(deps): bun update typescript to 5.9.4
-```
-**Action:** Excluded — internal tooling, no reader-visible change.
+- **Restating commit messages verbatim.** "Added MDX support" isn't reader-facing. Rewrite to describe what the reader now experiences.
+- **Including hashes or file paths.** Belong in `git log`, not a changelog.
+- **Padding empty changelogs.** If there are no user-facing changes, say so in one line.
+- **Overwriting `CHANGELOG.md`.** Always prepend; older sections stay intact.
+- **Running from the wrong worktree.** Confirm with `git rev-parse --show-toplevel`. In Conductor, this is a city-named worktree under the shared `website` project; the city differs across sessions.
 
 ## Tips
-- Run from the active worktree root (`git rev-parse --show-toplevel`) so `git log` sees the right history. In Conductor, this is usually a city-named worktree under the shared `website` project directory, and the city name may differ between sessions.
-- For a "weekly update post" framing, set the title to `# Week of <Monday's date>` instead of a version.
-- If `docs/specs/requirements.md` is relevant (e.g., a change touches the resolved-inputs table), mention the section in the rewrite — but only when it adds context for the reader.
-- Before publishing, re-read the draft aloud. If a sentence sounds like a release engineer wrote it, rewrite it.
+
+- For a "weekly update post", title with `# Week of <Monday's date>` instead of a version.
+- Re-read drafts aloud before publishing. If a sentence sounds like a release engineer wrote it, rewrite it.

--- a/.claude/skills/changelog-generator/SKILL.md
+++ b/.claude/skills/changelog-generator/SKILL.md
@@ -11,7 +11,7 @@ Turn git commit history on moster.dev into a clean, reader-friendly changelog. T
 
 1. **Pick a range.** Default to most recent semver tag (`git describe --tags --abbrev=0`) → `HEAD`. Fall back to past 7 days (`git log --since=7.days`) when no tag exists. Ask the user if the range is ambiguous — one question is cheaper than rewriting.
 2. **Read commits.** `git log <range> --pretty=format:"%H%x09%s%x09%b%x1e" --no-merges`. Skip merge commits.
-3. **Categorize.** Map each commit to **New**, **Improvements**, **Fixes**, **Breaking**, or **Internal** (filtered out). See the table below.
+3. **Categorize.** Map each commit to **New**, **Improvements**, **Fixes**, **Breaking**, or **Internal** (filtered out). See the table below. **If every commit lands in Internal, stop here** and return `No user-facing changes in this range.` as your entire output — don't promote a refactor or chore to fill the gap.
 4. **Rewrite for readers.** Convert `feat(blog): add MDX support` → `Posts now support rich formatting via MDX.` Short, declarative, present-tense, benefit-oriented.
 5. **Render Markdown** using the template below.
 6. **Show before saving.** Ask before writing to disk. When saving, prepend to existing `CHANGELOG.md` rather than overwriting.
@@ -30,6 +30,7 @@ Inspect both the commit prefix and the body. Multiple signals can apply — pick
 
 **Edge cases:**
 - A `chore:` that's actually user-visible (e.g., "chore: rewrite hero copy") belongs in **Improvements** — judge by impact, not prefix.
+- **Only upgrade when there's an observable change.** A refactor that moves code around (e.g., "refactor: pull theme variables into globals.css", "refactor: extract Nav component") stays **Internal**, even if the topic *sounds* user-facing. If you can't describe what a non-developer would see or feel differently, it's Internal.
 - Ambiguous commits go in the bucket the reader cares about more (a fix that adds a new affordance → **New**).
 - Drop entries too small to matter to readers (a typo fix in a deleted draft).
 
@@ -59,6 +60,7 @@ Drop empty sections. If the entire range produces no user-facing changes, return
 
 - **Present tense, active voice.** "Posts load 2x faster." not "We've improved post loading speed."
 - **Reader's perspective.** What the site does, not what you did. "Dark mode now follows your OS setting." beats "Implemented prefers-color-scheme."
+- **No technical jargon.** Avoid framework names (MDX, React) and implementation terms (frontmatter, SSR, hydration, prefers-color-scheme). Describe what the reader experiences, not the tech behind it. "Posts now support code blocks and callouts." beats "Posts now support MDX with frontmatter."
 - **No code or file references** in entry text. `src/components/Hero.tsx` doesn't belong in a changelog.
 - **No commit hashes** unless explicitly requested.
 - **Preserve "my pleasure".** Never paraphrase the canonical hero line (see CLAUDE.md).
@@ -76,8 +78,9 @@ Drop empty sections. If the entire range produces no user-facing changes, return
 ## Common mistakes
 
 - **Restating commit messages verbatim.** "Added MDX support" isn't reader-facing. Rewrite to describe what the reader now experiences.
+- **Leaking technical jargon.** Words like "MDX", "frontmatter", "SSR", or "prefers-color-scheme" mean nothing to a reader. Translate them ("rich post formatting", "follows your OS setting").
 - **Including hashes or file paths.** Belong in `git log`, not a changelog.
-- **Padding empty changelogs.** If there are no user-facing changes, say so in one line.
+- **Padding empty changelogs by promoting a refactor.** If every commit is internal (chore/refactor/build/ci/docs/test), don't reach for the closest user-adjacent one and dress it up. Return `No user-facing changes in this range.` and move on. A refactor with no observable behavior change is Internal, even if the words sound user-facing.
 - **Overwriting `CHANGELOG.md`.** Always prepend; older sections stay intact.
 - **Running from the wrong worktree.** Confirm with `git rev-parse --show-toplevel`. In Conductor, this is a city-named worktree under the shared `website` project; the city differs across sessions.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run: bun run build
       - run: bun test
       - run: bunx playwright test
+      - run: bunx playwright test -c playwright.built.config.ts
 
   deploy:
     needs: check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Updates — v1 (2026-05-18)
+
+moster.dev is live. This is the initial release.
+
+## New
+- **The site is live at moster.dev.** A single-page portfolio with a sticky top nav linking to Writing, About, and Contact.
+- **Hero introduction.** "Hi, I'm Jalo and I'm a Software Engineer at Chick-fil-A. It's my pleasure to invite you into my portfolio."
+- **Writing section.** A placeholder for the first post — more to come.
+- **About section.** A short introduction.
+- **Contact section.** Reach Jalo directly at jalo@moster.dev.
+- **Dark mode.** The site automatically follows your operating system's light or dark setting.
+- **Deep links work.** Sharing a link to any section opens the site to the right place.
+
+## Improvements
+- **Loads fast.** The site uses your device's built-in fonts, so nothing extra has to download before the page renders.
+- **Readable typography.** Generous line height and a comfortable reading width keep things easy on the eyes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Current state: v1 complete. `src/` ships Hero / Writing / About / Contact / Nav 
 - `playwright.config.ts`, `playwright.built.config.ts`, `playwright.production.config.ts` — browser E2E targets for dev server, built artifact, and production acceptance checks.
 - `worker-configuration.d.ts` — _(generated, gitignored)_ Worker runtime types, refreshed by `bunx wrangler types`.
 - `README.md` — user-facing project summary (stack, quickstart, deploy flow); keep in sync when the project layout changes.
+- `CHANGELOG.md` — reader-facing release notes (output of the `changelog-generator` skill); append a new dated section per release rather than rewriting prior entries.
 - `.husky/` — pre-commit hook installed automatically by `prepare` on `bun install`.
 
 ## Docs conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ test("hello world", () => {
 
 This repo is Jalo's personal website. **The authoritative requirements doc is `docs/specs/requirements.md` — read it before any non-trivial change.** It covers the deployment model, file layout, content sections, growth path, and the resolved decisions (domain, socials, hero copy, typography).
 
-Current state: v1 complete. `src/` ships Hero / Writing / About / Contact / Nav components, `scripts/dev.ts` + `scripts/build.ts` drive the Bun HTML bundler, `wrangler.toml` + `src/worker.ts` handle Workers + Static Assets, and `.github/workflows/ci.yml` runs check + e2e on PR and deploys on push to `master`. See `README.md` for the user-facing summary.
+Current state: v1 complete. `src/` ships Hero / Writing / About / Contact / Nav components, `scripts/dev.ts` + `scripts/build.ts` drive the Bun HTML bundler, `wrangler.toml` + `src/worker.ts` handle Workers + Static Assets, and `.github/workflows/ci.yml` runs check + dev/built E2E on PR and deploys on push to `master`. See `README.md` for the user-facing summary.
 
 ## Commands
 
@@ -58,7 +58,9 @@ Current state: v1 complete. `src/` ships Hero / Writing / About / Contact / Nav 
 | Type + lint check | `bun run check` (`wrangler types && biome check && tsc --noEmit`) |
 | Regenerate Worker types | `bunx wrangler types` |
 | Unit tests | `bun test` |
-| E2E (browser) | `bunx playwright test` against `bun run dev` |
+| E2E (dev server) | `bun run test:e2e` against `bun run dev` |
+| E2E (built artifact) | `bun run test:e2e:built` against `bun run preview` |
+| E2E (production) | `bun run test:e2e:production` against `PRODUCTION_URL` or `https://moster.dev` |
 
 ## Key files
 - `docs/specs/requirements.md` — authoritative requirements doc (read first).
@@ -71,6 +73,7 @@ Current state: v1 complete. `src/` ships Hero / Writing / About / Contact / Nav 
 - `.github/dependabot.yml` — weekly grouped Bun-ecosystem updates (open-PR limit 5); source of `Bump …` PRs like #3.
 - `.github/workflows/ci.yml` — single workflow with `check` (PRs + pushes) and `deploy` (push to `master`, needs `check`); canonical YAML in architecture §8.1.
 - `wrangler.toml`, `src/worker.ts` — Cloudflare Workers + Static Assets config and pass-through fetch handler.
+- `playwright.config.ts`, `playwright.built.config.ts`, `playwright.production.config.ts` — browser E2E targets for dev server, built artifact, and production acceptance checks.
 - `worker-configuration.d.ts` — _(generated, gitignored)_ Worker runtime types, refreshed by `bunx wrangler types`.
 - `README.md` — user-facing project summary (stack, quickstart, deploy flow); keep in sync when the project layout changes.
 - `.husky/` — pre-commit hook installed automatically by `prepare` on `bun install`.
@@ -98,8 +101,11 @@ Current state: v1 complete. `src/` ships Hero / Writing / About / Contact / Nav 
 
 ## Testing
 - **Unit / integration:** `bun test`. Files: `*.test.ts` colocated with source or under `tests/`.
-- **Browser smoke (E2E):** `bunx playwright test` runs specs under `tests/e2e/` against `bun run dev` (wired via `playwright.config.ts`). Each fresh machine or CI worker must run `bun run setup:browsers` (`playwright install chromium`) once before the first run.
-  - Keep specs thin: page loads, hero copy renders, all three social links resolve, dark mode applies via `prefers-color-scheme`. Don't snapshot the whole DOM.
+- **Browser smoke (dev E2E):** `bun run test:e2e` runs `tests/e2e/site.e2e.ts` against `bun run dev` (wired via `playwright.config.ts`).
+- **Built artifact acceptance:** `bun run test:e2e:built` runs `tests/e2e/built.e2e.ts` after `bun run build`, served through `wrangler dev` (wired via `playwright.built.config.ts`).
+- **Production acceptance:** `bun run test:e2e:production` runs `tests/e2e/production.e2e.ts` against `PRODUCTION_URL` or `https://moster.dev` (wired via `playwright.production.config.ts`).
+  - Each fresh machine or CI worker must run `bun run setup:browsers` (`playwright install chromium`) once before the first run.
+  - Keep specs thin: page loads, hero copy renders, all three social links resolve, dark mode applies via `prefers-color-scheme`, Tailwind utilities are present, and SPA fallback works. Don't snapshot the whole DOM.
 - **Interactive verification during a task:** use the `mcp__plugin_playwright_playwright__*` MCP tools to drive a browser ad-hoc rather than writing throwaway specs. Per the global rule, UI changes must be exercised in a browser before being reported as complete.
 
 ## Agents and skills

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Jalo Moster's personal website — a single-page React SPA deployed to Cloudflare Workers with Static Assets.
 
-**Status:** v1 complete. Hero, Writing (empty state), About, and Contact sections live; light/dark theming via `prefers-color-scheme`; smoke + Playwright E2E coverage; CI and production deploys on push to `master`.
+**Status:** v1 complete. Hero, Writing (empty state), About, and Contact sections live; light/dark theming via `prefers-color-scheme`; smoke + Playwright E2E coverage for dev, built, and production targets; CI and production deploys on push to `master`.
 
 ## Stack
 
@@ -33,7 +33,9 @@ bun run dev              # http://localhost:3000 with HMR
 | `bun run deploy` | `wrangler deploy` — break-glass only; prod deploys run from GitHub Actions. |
 | `bun run check` | `wrangler types && biome check && tsc --noEmit`. |
 | `bun test` | Unit / integration tests. |
-| `bunx playwright test` | Browser E2E specs under `tests/e2e/`. |
+| `bun run test:e2e` | Browser E2E against the Bun dev server. |
+| `bun run test:e2e:built` | Browser E2E against a freshly built `dist/` served by `wrangler dev`. |
+| `bun run test:e2e:production` | Browser E2E against `PRODUCTION_URL` or `https://moster.dev`. |
 | `bun run setup:browsers` | `playwright install chromium`. |
 
 ## Project layout
@@ -51,7 +53,9 @@ scripts/
   build.ts              # Bun.build + public/ copy
 tests/
   smoke.test.ts         # bun test
-  e2e/site.e2e.ts       # Playwright
+  e2e/site.e2e.ts       # Playwright against bun run dev
+  e2e/built.e2e.ts      # Playwright against bun run preview
+  e2e/production.e2e.ts # Playwright against moster.dev / PRODUCTION_URL
 public/                 # static assets outside the bundler graph (favicon, robots.txt)
 docs/
   specs/                # requirements, architecture, per-feature specs
@@ -67,14 +71,16 @@ Light and dark schemes are driven by `prefers-color-scheme` — no toggle. Desig
 ## Testing
 
 - **Unit:** `bun test` — specs colocated with source or under `tests/`.
-- **E2E:** `bunx playwright test` against `bun run dev`. Coverage: page loads, hero copy renders verbatim, all three social links resolve, dark mode applies via `prefers-color-scheme`.
+- **Dev E2E:** `bun run test:e2e` against `bun run dev`. Coverage: page loads, hero copy renders verbatim, all three social links resolve, dark mode applies via `prefers-color-scheme`.
+- **Built E2E:** `bun run test:e2e:built` builds `dist/`, serves it through `wrangler dev`, and verifies Tailwind output plus SPA fallback behavior.
+- **Production E2E:** `bun run test:e2e:production` runs the same acceptance checks against `PRODUCTION_URL` or `https://moster.dev`.
 - A fresh machine can recreate the full test environment with `bun install && bun run setup:browsers`.
 
 ## Deployment
 
 Production deploys run automatically on push to `master`:
 
-1. `check` job: `bun install --frozen-lockfile`, `setup:browsers`, `check`, `build`, `bun test`, `bunx playwright test`.
+1. `check` job: `bun install --frozen-lockfile`, `setup:browsers`, `check`, `build`, `bun test`, `bunx playwright test`, `bun run test:e2e:built`.
 2. `deploy` job (depends on `check`): builds and ships `dist/` via `cloudflare/wrangler-action@v3`.
 
 Cloudflare credentials live as GitHub Actions secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and are never committed. `bun run deploy` from a developer machine is supported as a break-glass path but is not the source of truth.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "preview": "wrangler dev",
     "deploy": "wrangler deploy",
     "test": "bun test",
+    "test:e2e": "playwright test",
+    "test:e2e:built": "playwright test -c playwright.built.config.ts",
+    "test:e2e:production": "playwright test -c playwright.production.config.ts",
     "setup:browsers": "playwright install chromium",
     "check": "wrangler types && biome check && tsc --noEmit",
     "prepare": "husky && wrangler types"

--- a/playwright.built.config.ts
+++ b/playwright.built.config.ts
@@ -2,15 +2,16 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "tests/e2e",
-  testMatch: "**/site.e2e.ts",
+  testMatch: "**/built.e2e.ts",
   fullyParallel: true,
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: "http://localhost:8787",
   },
   webServer: {
-    command: "bun run dev",
-    url: "http://localhost:3000",
+    command: "bun run build && bun run preview",
+    url: "http://localhost:8787",
     reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
   projects: [
     {

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -2,15 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "tests/e2e",
-  testMatch: "**/site.e2e.ts",
+  testMatch: "**/production.e2e.ts",
   fullyParallel: true,
   use: {
-    baseURL: "http://localhost:3000",
-  },
-  webServer: {
-    command: "bun run dev",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
+    baseURL: process.env.PRODUCTION_URL ?? "https://moster.dev",
   },
   projects: [
     {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,5 @@
 import { cp, rm } from "node:fs/promises";
+import tailwindPlugin from "bun-plugin-tailwind";
 
 await rm("dist", { recursive: true, force: true });
 
@@ -8,6 +9,7 @@ const result = await Bun.build({
   publicPath: "/",
   minify: true,
   sourcemap: "linked",
+  plugins: [tailwindPlugin],
 });
 
 if (!result.success) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 
+// biome-ignore lint/style/noNonNullAssertion: #root is defined in src/index.html
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />

--- a/tests/e2e/built.e2e.ts
+++ b/tests/e2e/built.e2e.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+
+test("built artifact serves the SPA shell", async ({ page }) => {
+  const response = await page.goto("/");
+  expect(response?.status()).toBe(200);
+  await expect(page.locator("#root")).toBeAttached();
+});
+
+test("built artifact renders the canonical hero copy verbatim", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(
+    page.getByText("It's my pleasure to invite you into my portfolio."),
+  ).toBeVisible();
+});
+
+test("built artifact exposes the three canonical social links", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(
+    page.locator("a[href='https://github.com/jlvmoster']"),
+  ).toBeVisible();
+  await expect(
+    page.locator("a[href='https://instagram.com/jlvmoster']"),
+  ).toBeVisible();
+  await expect(
+    page.locator("a[href='https://linkedin.com/in/jlvmoster']"),
+  ).toBeVisible();
+});
+
+test("built artifact applies Tailwind utility classes", async ({ page }) => {
+  await page.goto("/");
+
+  const heroStyles = await page.locator("#hero").evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      maxWidth: cs.maxWidth,
+      paddingLeft: parseFloat(cs.paddingLeft),
+      paddingTop: parseFloat(cs.paddingTop),
+    };
+  });
+  expect(heroStyles.maxWidth).not.toBe("none");
+  expect(heroStyles.paddingLeft).toBeGreaterThan(0);
+  expect(heroStyles.paddingTop).toBeGreaterThan(0);
+
+  const heroHeadingStyles = await page.locator("#hero h1").evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      fontFamily: cs.fontFamily,
+      fontSize: parseFloat(cs.fontSize),
+    };
+  });
+  expect(heroHeadingStyles.fontFamily.toLowerCase()).toContain("serif");
+  expect(heroHeadingStyles.fontSize).toBeGreaterThanOrEqual(24);
+
+  const ghLinkDisplay = await page
+    .locator("a[href='https://github.com/jlvmoster']")
+    .evaluate((el) => getComputedStyle(el).display);
+  expect(ghLinkDisplay).toBe("inline-flex");
+});
+
+test("built artifact applies dark mode via prefers-color-scheme", async ({
+  browser,
+}) => {
+  const readBodyBackground = async (colorScheme: "light" | "dark") => {
+    const context = await browser.newContext({ colorScheme });
+    const page = await context.newPage();
+    try {
+      await page.goto("/");
+      return await page
+        .locator("body")
+        .evaluate((el) => getComputedStyle(el).backgroundColor);
+    } finally {
+      await context.close();
+    }
+  };
+
+  const lightBg = await readBodyBackground("light");
+  const darkBg = await readBodyBackground("dark");
+
+  expect(lightBg).not.toBe(darkBg);
+});
+
+test("built artifact returns the SPA shell for unknown paths", async ({
+  page,
+}) => {
+  const response = await page.goto("/some-unknown-path");
+  expect(response?.status()).toBe(200);
+  await expect(page.locator("#root")).toBeAttached();
+});

--- a/tests/e2e/production.e2e.ts
+++ b/tests/e2e/production.e2e.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+
+test("production serves the SPA shell over HTTPS", async ({ page }) => {
+  const response = await page.goto("/");
+  expect(response?.status()).toBe(200);
+  expect(response?.url().startsWith("https://")).toBe(true);
+  await expect(page.locator("#root")).toBeAttached();
+});
+
+test("production renders the canonical hero copy verbatim", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(
+    page.getByText("It's my pleasure to invite you into my portfolio."),
+  ).toBeVisible();
+});
+
+test("production exposes the three canonical social links", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(
+    page.locator("a[href='https://github.com/jlvmoster']"),
+  ).toBeVisible();
+  await expect(
+    page.locator("a[href='https://instagram.com/jlvmoster']"),
+  ).toBeVisible();
+  await expect(
+    page.locator("a[href='https://linkedin.com/in/jlvmoster']"),
+  ).toBeVisible();
+});
+
+test("production applies Tailwind utility classes", async ({ page }) => {
+  await page.goto("/");
+
+  const heroStyles = await page.locator("#hero").evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      maxWidth: cs.maxWidth,
+      paddingLeft: parseFloat(cs.paddingLeft),
+      paddingTop: parseFloat(cs.paddingTop),
+    };
+  });
+  expect(heroStyles.maxWidth).not.toBe("none");
+  expect(heroStyles.paddingLeft).toBeGreaterThan(0);
+  expect(heroStyles.paddingTop).toBeGreaterThan(0);
+
+  const heroHeadingStyles = await page.locator("#hero h1").evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      fontFamily: cs.fontFamily,
+      fontSize: parseFloat(cs.fontSize),
+    };
+  });
+  expect(heroHeadingStyles.fontFamily.toLowerCase()).toContain("serif");
+  expect(heroHeadingStyles.fontSize).toBeGreaterThanOrEqual(24);
+
+  const ghLinkDisplay = await page
+    .locator("a[href='https://github.com/jlvmoster']")
+    .evaluate((el) => getComputedStyle(el).display);
+  expect(ghLinkDisplay).toBe("inline-flex");
+});
+
+test("production applies dark mode via prefers-color-scheme", async ({
+  browser,
+}) => {
+  const readBodyBackground = async (colorScheme: "light" | "dark") => {
+    const context = await browser.newContext({ colorScheme });
+    const page = await context.newPage();
+    try {
+      await page.goto("/");
+      return await page
+        .locator("body")
+        .evaluate((el) => getComputedStyle(el).backgroundColor);
+    } finally {
+      await context.close();
+    }
+  };
+
+  const lightBg = await readBodyBackground("light");
+  const darkBg = await readBodyBackground("dark");
+
+  expect(lightBg).not.toBe(darkBg);
+});
+
+test("production returns the SPA shell for unknown paths", async ({ page }) => {
+  const response = await page.goto("/some-unknown-path");
+  expect(response?.status()).toBe(200);
+  await expect(page.locator("#root")).toBeAttached();
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,6 +10,10 @@ not_found_handling = "single-page-application"  # serves index.html for unknown 
 [vars]
 # env vars here later
 
+[observability.logs]
+enabled = true
+invocation_logs = true
+
 # When you add a Worker fetch handler (forms, API, OG images), uncomment:
 # [[routes]]
 # pattern = "moster.dev/api/*"


### PR DESCRIPTION
Adds built-artifact and production Playwright suites so acceptance checks can run against both Wrangler preview and the live site. Wires the built-artifact suite into CI, narrows the default Playwright config to the dev-server suite, and adds package scripts for each E2E target. Enables the Tailwind Bun build plugin so production builds include utility CSS, turns on Cloudflare invocation logs, and updates README/CLAUDE docs for the new verification paths.\n\nVerified locally with `bun run check`, `bun run build`, `bun test`, `bun run test:e2e`, and `bun run test:e2e:built`.