### PR TITLE
Enable Workers trace observability

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,9 @@ not_found_handling = "single-page-application"  # serves index.html for unknown 
 enabled = true
 invocation_logs = true
 
+[observability.traces]
+enabled = true
+
 # When you add a Worker fetch handler (forms, API, OG images), uncomment:
 # [[routes]]
 # pattern = "moster.dev/api/*"


### PR DESCRIPTION
## Summary
- Add `[observability.traces] enabled = true` to `wrangler.toml` so the deployed Worker streams traces alongside the existing invocation logs, giving us request-flow visibility in the Cloudflare dashboard.

## Test plan
- [ ] `bun run check` passes locally.
- [ ] After merge, confirm traces appear under the Worker's Observability tab in the Cloudflare dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)