### PR TITLE
Add post-deploy Lighthouse CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,11 @@ on:
     branches: [master]
   push:
     branches: [master]
+  schedule:
+    - cron: '0 7 * * *'
 jobs:
   check:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -53,3 +56,19 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  lighthouse:
+    needs: deploy
+    if: always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Wait for deploy to propagate
+        if: github.event_name == 'push'
+        run: sleep 30
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [master]
   schedule:
     - cron: '0 7 * * *'
+permissions:
+  contents: read
 jobs:
   check:
     if: github.event_name != 'schedule'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Updates — v2.2.0 (2026-05-19)
+
+Site reliability work — nothing visible on the page, but the deploy pipeline is now self-auditing and runs with the minimum permissions it needs.
+
+## Internal
+- Every production deploy now runs a Lighthouse audit against the live site and reports the scores back to the build, so regressions in performance, accessibility, or best practices surface automatically instead of waiting to be noticed by hand.
+- The deploy workflow runs with read-only token permissions by default, scoping write access only to the steps that need it.
+
+---
+
 # Updates — v2.1.0 (2026-05-19)
 
 A round of Lighthouse-driven polish: faster paints, accessible contrast, per-page browser metadata, and tighter security defaults.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ Current state: v2 redesign complete. Multi-page React 19 SPA via `react-router-d
 - `.claude/settings.json` — enabled plugins and Bash permission allowlist.
 - `.github/CODEOWNERS` — requires `@jlvmoster` review on every PR.
 - `.github/dependabot.yml` — weekly grouped Bun-ecosystem updates (open-PR limit 5); source of `Bump …` PRs like #3.
-- `.github/workflows/ci.yml` — single workflow with `check` (PRs + pushes) and `deploy` (push to `master`, needs `check`); canonical YAML in architecture §8.1.
+- `.github/workflows/ci.yml` — single workflow with `check` (PRs + pushes), `deploy` (push to `master`, needs `check`), and `lighthouse` (post-deploy + nightly `schedule`, needs `deploy`); canonical YAML in architecture §8.1.
+- `lighthouserc.json` — Lighthouse CI config at repo root; URL list (`/`, `/about`, `/articles`), `numberOfRuns: 3`, Core Web Vitals assertions with `aggregationMethod: "median"`, `temporary-public-storage` upload target. See `docs/specs/features/lighthouse-ci.md`.
 - `wrangler.toml`, `src/worker.ts` — Cloudflare Workers + Static Assets config and pass-through fetch handler.
 - `playwright.config.ts`, `playwright.built.config.ts`, `playwright.production.config.ts` — browser E2E targets for dev server, built artifact, and production acceptance checks.
 - `worker-configuration.d.ts` — _(generated, gitignored)_ Worker runtime types, refreshed by `bunx wrangler types`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Jalo Moster's personal website — a multi-page React SPA deployed to Cloudflare
 - **Hosting:** Cloudflare Workers + Static Assets (not Pages) on `moster.dev`. SPA fallback handles deep-link refreshes.
 - **Lint / format:** Biome. **Types:** TypeScript strict mode + generated Worker types.
 - **Testing:** `bun test` for units, `@playwright/test` for browser E2E.
-- **CI/CD:** GitHub Actions — `check` on every PR/push, `deploy` on push to `master` via `cloudflare/wrangler-action@v3`.
+- **CI/CD:** GitHub Actions — `check` on every PR/push, `deploy` on push to `master` via `cloudflare/wrangler-action@v3`, and `lighthouse` post-deploy + nightly via `treosh/lighthouse-ci-action@v12`.
 
 No Vite, webpack, esbuild, Next.js, MDX, or third-party UI component libraries — the Bun HTML bundler is the entire build pipeline. `react-router-dom`, `clsx`, and `@tailwindcss/typography` are utilities/plugins and are permitted.
 
@@ -86,6 +86,7 @@ docs/
   specs/                  # requirements, architecture, per-feature specs
   tasks/                  # numbered implementation playbook (01–13)
 wrangler.toml             # Workers + Static Assets config
+lighthouserc.json         # Lighthouse CI thresholds (LCP/CLS/perf-score, median of N=3)
 worker-configuration.d.ts # generated, gitignored
 ```
 
@@ -109,6 +110,7 @@ Production deploys run automatically on push to `master`:
 
 1. `check` job: `bun install --frozen-lockfile`, `setup:browsers`, `check`, `build`, `bun test`, `bunx playwright test`, `bun run test:e2e:built`.
 2. `deploy` job (depends on `check`): builds and ships `dist/` via `cloudflare/wrangler-action@v3`.
+3. `lighthouse` job (depends on `deploy`, also runs on a nightly `schedule` cron): asserts Core Web Vitals budgets against `https://moster.dev` via `treosh/lighthouse-ci-action@v12` using thresholds in `lighthouserc.json`. Not a PR merge gate; failures alert rather than block.
 
 Cloudflare credentials live as GitHub Actions secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and are never committed. `bun run deploy` from a developer machine is supported as a break-glass path but is not the source of truth.
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -464,6 +464,8 @@ on:
     branches: [master]
   schedule:
     - cron: '0 7 * * *'
+permissions:
+  contents: read
 jobs:
   check:
     if: github.event_name != 'schedule'
@@ -532,7 +534,7 @@ jobs:
           temporaryPublicStorage: true
 ```
 
-The `check` job order matches the fresh-machine bootstrap in `features/tooling.md`. The cache keys include `hashFiles('bun.lock')`, so dependency or Playwright-version changes naturally create fresh caches. `setup:browsers` still runs after cache restore for the same reason §NFR-2.4.4 calls it out: do not depend on a pre-existing Playwright cache being complete or warm. `--frozen-lockfile` ensures PRs that touch dependencies also commit `bun.lock`.
+The workflow scopes `GITHUB_TOKEN` to `contents: read`, which is enough for checkout while leaving deploy authentication to Cloudflare secrets. The `check` job order matches the fresh-machine bootstrap in `features/tooling.md`. The cache keys include `hashFiles('bun.lock')`, so dependency or Playwright-version changes naturally create fresh caches. `setup:browsers` still runs after cache restore for the same reason §NFR-2.4.4 calls it out: do not depend on a pre-existing Playwright cache being complete or warm. `--frozen-lockfile` ensures PRs that touch dependencies also commit `bun.lock`.
 
 `actions/setup-node@v6` is provisioned before `oven-sh/setup-bun@v2` because `bun run check` invokes `wrangler types` (Node-based) and `cloudflare/wrangler-action@v3` in the `deploy` job also expects Node available on PATH. `bun run build` runs in `check` to catch bundler breakage before merge; the second `bunx playwright test -c playwright.built.config.ts` exercises the built artifact through `wrangler dev`, so PR gating covers both the dev-server and the built-artifact code paths described in `features/testing.md`.
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -462,11 +462,17 @@ on:
     branches: [master]
   push:
     branches: [master]
+  schedule:
+    - cron: '0 7 * * *'
 jobs:
   check:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun packages
         uses: actions/cache@v5
@@ -481,8 +487,10 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run setup:browsers
       - run: bun run check
+      - run: bun run build
       - run: bun test
       - run: bunx playwright test
+      - run: bunx playwright test -c playwright.built.config.ts
 
   deploy:
     needs: check
@@ -490,6 +498,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun packages
         uses: actions/cache@v5
@@ -503,9 +514,27 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  lighthouse:
+    needs: deploy
+    if: always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Wait for deploy to propagate
+        if: github.event_name == 'push'
+        run: sleep 30
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true
 ```
 
 The `check` job order matches the fresh-machine bootstrap in `features/tooling.md`. The cache keys include `hashFiles('bun.lock')`, so dependency or Playwright-version changes naturally create fresh caches. `setup:browsers` still runs after cache restore for the same reason §NFR-2.4.4 calls it out: do not depend on a pre-existing Playwright cache being complete or warm. `--frozen-lockfile` ensures PRs that touch dependencies also commit `bun.lock`.
+
+`actions/setup-node@v6` is provisioned before `oven-sh/setup-bun@v2` because `bun run check` invokes `wrangler types` (Node-based) and `cloudflare/wrangler-action@v3` in the `deploy` job also expects Node available on PATH. `bun run build` runs in `check` to catch bundler breakage before merge; the second `bunx playwright test -c playwright.built.config.ts` exercises the built artifact through `wrangler dev`, so PR gating covers both the dev-server and the built-artifact code paths described in `features/testing.md`.
 
 ### 8.2 CD Through GitHub Actions
 
@@ -530,6 +559,19 @@ Branch protection should require `check` before merge. The deploy job is not a p
 - **GitHub now holds deploy credentials.** This is the direct tradeoff for keeping CI/CD in one GitHub Actions workflow. The token must be scoped narrowly in Cloudflare and stored only as a GitHub Actions secret.
 - **Cache package artifacts, not `node_modules`.** CI caches Bun's package cache and Playwright's browser archive using exact `bun.lock` keys. Playwright notes that browser-cache restore can be comparable to download time, so this is a measured tradeoff rather than a correctness dependency. The workflow still runs `bun install --frozen-lockfile` and `bun run setup:browsers`, which keeps it reproducible on cache misses and avoids relying on a committed or restored `node_modules` tree.
 
+### 8.5 Post-deploy Lighthouse CI
+
+Requirements §1.8 adds a third job, `lighthouse`, to the same `ci.yml`. It runs `@lhci/cli` via [`treosh/lighthouse-ci-action@v12`](https://github.com/treosh/lighthouse-ci-action) against `https://moster.dev` after every production deploy and on a daily `schedule:` cron, asserting Core Web Vitals budgets defined in `lighthouserc.json` at the repo root. The per-feature implementation spec is at [features/lighthouse-ci.md](features/lighthouse-ci.md).
+
+**Why this shape:**
+
+- **Post-deploy, not PR-gating.** Lighthouse runs on a shared GitHub runner are noisy; per-PR enforcement would block merges on jitter rather than real regressions. Running against the *deployed* site, against absolute Core Web Vitals cutoffs, with N=3 runs and `aggregationMethod: "median"`, gives a trustworthy signal at the cost of detecting regressions slightly after they ship. Recovery is a roll-back, not a merge block.
+- **One workflow, three jobs.** `check` and `deploy` are unchanged; `lighthouse` chains off `deploy` via `needs:`. The `if: always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')` guard makes the job fire on both `push` (after a successful deploy) and `schedule` (where `deploy` is skipped). The `check` job adds `if: github.event_name != 'schedule'` so the cron run does not re-run the full test suite.
+- **`treosh/lighthouse-ci-action` over rolling our own.** The official `GoogleChrome/lighthouse-ci` repo points readers at this community action; it's a thin wrapper around `@lhci/cli` with GH-native artifact and public-storage upload paths.
+- **No LHCI Server.** Historical diffs and a status-check integration require self-hosting Postgres + a server. For a personal site, the `temporary-public-storage` link in the workflow log plus the uploaded HTML artifact are enough; this stays consistent with §NFR-2.2.2 (no paid third-party services for v1).
+
+**Cost.** One ubuntu-latest runner × ~5 min × (push frequency + nightly) is well under the GitHub Actions free tier ceiling per §NFR-2.2.3.
+
 ## 9. Sources
 
 - [Static Assets · Cloudflare Workers docs](https://developers.cloudflare.com/workers/static-assets/)
@@ -543,3 +585,6 @@ Branch protection should require `check` before merge. The deploy job is not a p
 - [Workers & Pages Pricing · Cloudflare](https://www.cloudflare.com/plans/developer-platform/)
 - [GitHub Actions billing & free-tier minutes · GitHub Docs](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
 - [oven-sh/setup-bun action](https://github.com/oven-sh/setup-bun)
+- [Lighthouse CI · GoogleChrome](https://github.com/GoogleChrome/lighthouse-ci) — `@lhci/cli`, assertions, presets
+- [treosh/lighthouse-ci-action](https://github.com/treosh/lighthouse-ci-action) — GitHub Actions wrapper used in `ci.yml`
+- [Core Web Vitals thresholds · web.dev](https://web.dev/articles/vitals) — LCP/CLS/INP "good" cutoffs anchoring §NFR-2.5

--- a/docs/specs/features/ci-cd.md
+++ b/docs/specs/features/ci-cd.md
@@ -4,7 +4,7 @@
 Automated CI on every PR and push to `master`, and automated production deploys on push to `master` through GitHub Actions using Cloudflare's official Wrangler action.
 
 ## Requirements covered
-- §FR-1.7.1 — CI on every PR and push runs `bun install --frozen-lockfile`, `bun run setup:browsers`, `bun run check`, `bun test`, `bunx playwright test`.
+- §FR-1.7.1 — CI on every PR and push runs `bun install --frozen-lockfile`, `bun run setup:browsers`, `bun run check`, `bun run build`, `bun test`, `bunx playwright test`, and `bunx playwright test -c playwright.built.config.ts`.
 - §FR-1.7.2 — Push to `master` triggers an automated production deploy after CI passes.
 - §FR-1.7.3 — CI and CD both run on GitHub Actions; deploys use `cloudflare/wrangler-action@v3`.
 - §FR-1.7.4 — Workflow files committed under `.github/workflows/`.
@@ -19,11 +19,12 @@ Automated CI on every PR and push to `master`, and automated production deploys 
 
 ## Behavior & edge cases
 - **Workflow (`.github/workflows/ci.yml`):**
-  - Triggers: `pull_request` against `master`, and `push` to `master`.
-  - `check` job runs on `ubuntu-latest`.
-  - `check` steps in order: `actions/checkout@v6` → `oven-sh/setup-bun@v2` → restore Bun package cache → restore Playwright browser cache → `bun install --frozen-lockfile` → `bun run setup:browsers` → `bun run check` → `bun test` → `bunx playwright test`.
+  - Triggers: `pull_request` against `master`, `push` to `master`, and a `schedule: '0 7 * * *'` cron that fires only the `lighthouse` job (see `features/lighthouse-ci.md`).
+  - `check` job runs on `ubuntu-latest` and is gated with `if: github.event_name != 'schedule'` so cron runs do not re-execute the suite.
+  - `check` steps in order: `actions/checkout@v6` → `actions/setup-node@v6` (node 22) → `oven-sh/setup-bun@v2` → restore Bun package cache → restore Playwright browser cache → `bun install --frozen-lockfile` → `bun run setup:browsers` → `bun run check` → `bun run build` → `bun test` → `bunx playwright test` → `bunx playwright test -c playwright.built.config.ts`.
   - `deploy` job has `needs: check` and only runs when `github.event_name == 'push' && github.ref == 'refs/heads/master'`.
-  - `deploy` steps: `actions/checkout@v6` → `oven-sh/setup-bun@v2` → restore Bun package cache → `bun install --frozen-lockfile` → `bun run build` → `cloudflare/wrangler-action@v3`.
+  - `deploy` steps: `actions/checkout@v6` → `actions/setup-node@v6` (node 22) → `oven-sh/setup-bun@v2` → restore Bun package cache → `bun install --frozen-lockfile` → `bun run build` → `cloudflare/wrangler-action@v3`.
+  - `lighthouse` job (`needs: deploy`, `if: always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')`) runs post-deploy and on the daily cron; see `features/lighthouse-ci.md` for behavior.
   - The Wrangler action receives `apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}` and `accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}`.
   - `--frozen-lockfile` enforces that PRs touching dependencies update `bun.lock`.
   - Cache Bun packages with `actions/cache@v5`, path `~/.bun/install/cache`, key `bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}`.

--- a/docs/specs/features/lighthouse-ci.md
+++ b/docs/specs/features/lighthouse-ci.md
@@ -1,0 +1,49 @@
+# Lighthouse CI — Implementation Spec
+
+## Goal
+Post-deploy performance monitoring against `https://moster.dev` that asserts Core Web Vitals budgets on every push to `master` and on a nightly schedule. Failures alert; they do not gate PR merges.
+
+## Requirements covered
+- §FR-1.8.1 — Lighthouse runs against the live site on a representative set of routes after every production deploy.
+- §FR-1.8.2 — Budgets live in committed `lighthouserc.json`; assertions run via `@lhci/cli` invoked through `treosh/lighthouse-ci-action`.
+- §FR-1.8.3 — Triggered on push to `master` (after `deploy`) and on a daily `schedule:` cron. Not a PR merge gate.
+- §FR-1.8.4 — `numberOfRuns: 3` with `aggregationMethod: "median"` on every assertion.
+- §FR-1.8.5 — Reports uploaded to Google's temporary public storage and saved as a GitHub Actions artifact.
+- §NFR-2.5.1 — LCP median ≤ 2500 ms (`error`).
+- §NFR-2.5.2 — CLS median ≤ 0.1 (`error`).
+- §NFR-2.5.3 — TBT median ≤ 200 ms (`warn`).
+- §NFR-2.5.4 — Performance category median ≥ 0.9 (`error`).
+- §NFR-2.2.3 — Stays on GitHub Actions' free tier (one runner, ~5 minutes, runs only on master + nightly).
+
+## File layout
+- `lighthouserc.json` — repo root, consumed by the action via `configPath`. Holds the URL list, run count, assertion thresholds, and upload target.
+- `.github/workflows/ci.yml` — single workflow now hosts three jobs: `check`, `deploy`, `lighthouse`. See [architecture §8.1](../architecture.md#81-ci-on-github-actions) for the canonical YAML and [§8.5](../architecture.md#85-post-deploy-lighthouse-ci) for the design rationale.
+- No new dependency in `package.json`; the action provisions `@lhci/cli` in the runner.
+
+## Behavior & edge cases
+- **Trigger surface:**
+  - `push` to `master` → `check` → `deploy` → `lighthouse` (in that order, via `needs:` chain).
+  - `schedule` (`0 7 * * *` UTC) → only `lighthouse` runs; `check` is skipped via `if: github.event_name != 'schedule'`, `deploy` is skipped by its existing event-name guard, and `lighthouse` evaluates because of `always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')`.
+  - `pull_request` → `check` runs; `deploy` and `lighthouse` are skipped. Lighthouse never gates a PR.
+- **Audited routes (in `lighthouserc.json`):** `/`, `/about`, `/articles`. Keeps audit time bounded (~5 min for 3 URLs × 3 runs) and covers the three structurally distinct pages (Home hero + avatar scaling, image-heavy About, list page). Adding `/projects` and `/uses` is a one-line edit when their performance becomes a concern.
+- **Run count and aggregation:** `numberOfRuns: 3` with `aggregationMethod: "median"` on each assertion. Single-run Lighthouse on shared GH runners commonly swings ±500 ms on LCP; the median across three runs absorbs that.
+- **Lighthouse settings:** `preset: "desktop"`. The site's audience is desktop-first portfolio readers, and desktop preset reduces runner-throttling noise vs. the mobile default. A future `mobile` matrix entry would be additive, not a swap.
+- **Assertion levels:**
+  - `error` on LCP, CLS, and `categories:performance` — these are the absolute Core Web Vitals "good" cutoffs; a failure indicates a real regression.
+  - `warn` on TBT — TBT is a lab-only proxy for the production INP signal; a failed budget is informational.
+- **Assertion scope:** `lighthouserc.json` intentionally omits LHCI assertion presets such as `lighthouse:no-pwa`; only the explicit Core Web Vitals and performance-score budgets above are enforced. Broader accessibility, SEO, best-practices, or image-optimization audits should be added as separate requirements when they become intentional gates.
+- **Deploy → measurement gap:** the `lighthouse` job sleeps 30 s on the `push` path (`if: github.event_name == 'push'`) so Cloudflare's global propagation completes before the audit. The schedule path skips the sleep because production is already live.
+- **Report surfacing:** `temporaryPublicStorage: true` posts a shareable link in the workflow log (Google-hosted, no auth, no history). `uploadArtifacts: true` also stashes the raw HTML report as a workflow artifact. No LHCI Server is provisioned for v1 (§FR-1.8.5).
+- **Failure semantics:** a Lighthouse assertion failure marks the workflow run red and emails the repo owner via GitHub's default notifications. The site stays on the just-deployed revision; rolling back is a manual decision based on the report link.
+- **Cost:** one ubuntu-latest runner × ~5 min × (push-frequency + nightly) stays well under the free-tier 2,000 min/month even with daily runs.
+
+## Test plan
+- **First-run smoke:** merge this feature to `master`, watch CI; confirm `lighthouse` job runs after `deploy`, posts a `temporary-public-storage` URL in the log, and uploads an artifact.
+- **Scheduled-run smoke:** on the next nightly cron firing, confirm a workflow run appears with only `lighthouse` executed (no `check`, no `deploy`).
+- **Failing-budget rehearsal:** temporarily lower `largest-contentful-paint.maxNumericValue` to `100` in `lighthouserc.json` on a throwaway branch, push to `master`, confirm the `lighthouse` job fails red and the linked report shows the assertion. Revert.
+- **PR isolation:** open a PR; confirm `lighthouse` does not run and is not listed as a required check in branch protection.
+
+## Open questions
+- Add a separate **mobile** preset matrix entry? Deferred — desktop-first audience, and a second preset doubles audit time.
+- Move to a self-hosted LHCI Server (`serverBaseUrl` + `serverToken`) for historical diffing? Deferred per §FR-1.8.5 — not worth the Postgres + Heroku/Docker footprint for a personal site.
+- Add a `budget.json` for byte-size budgets (JS/CSS/images)? Deferred until a regression actually demands it; the assertion budgets above already catch LCP regressions caused by oversized assets.

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -78,12 +78,19 @@ This document is the authoritative source of truth for what the implementation m
 - **FR-1.6.3** `worker-configuration.d.ts` is gitignored; type generation is part of `bun run check` and CI.
 
 ### 1.7 CI/CD
-- **FR-1.7.1** Every pull request against `master` and every push to `master` triggers an automated CI run that executes `bun install --frozen-lockfile`, `bun run setup:browsers`, `bun run check`, `bun test`, and `bunx playwright test`. A PR cannot merge until CI is green.
+- **FR-1.7.1** Every pull request against `master` and every push to `master` triggers an automated CI run that executes `bun install --frozen-lockfile`, `bun run setup:browsers`, `bun run check`, `bun run build`, `bun test`, `bunx playwright test`, and `bunx playwright test -c playwright.built.config.ts`. A PR cannot merge until CI is green.
 - **FR-1.7.2** Pushes to `master` trigger an automated production deploy through GitHub Actions after CI passes. Production releases must not require an interactive `bun run deploy` from a developer's machine.
 - **FR-1.7.3** CI and CD both run on GitHub Actions. Deploys use Cloudflare's official `cloudflare/wrangler-action@v3`.
 - **FR-1.7.4** Workflow definitions live under `.github/workflows/` and are committed.
 - **FR-1.7.5** Cloudflare API credentials needed for deploys are stored only as GitHub Actions secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and are never committed to the repository.
 - **FR-1.7.6** `bun run deploy` remains supported as a break-glass path (§FR-1.5.4) but is not the production source of truth.
+
+### 1.8 Performance monitoring
+- **FR-1.8.1** Production deploys are followed by an automated Lighthouse CI run against the live site that measures Core Web Vitals (LCP, CLS) and total blocking time on a representative set of routes.
+- **FR-1.8.2** Lighthouse thresholds live in a committed `lighthouserc.json` at the repo root and are asserted via `@lhci/cli` invoked through `treosh/lighthouse-ci-action`.
+- **FR-1.8.3** The Lighthouse job runs after the `deploy` job on push to `master`, and also on a daily `schedule` trigger so regressions surface even when no code changes have shipped. It is not a PR merge gate.
+- **FR-1.8.4** Each Lighthouse run executes ≥ 3 audits per URL and asserts against the median, to absorb runner variance.
+- **FR-1.8.5** Each run uploads its HTML report to Google's temporary public storage (link in workflow logs) and as a GitHub Actions artifact; no self-hosted LHCI Server is introduced for v1.
 
 ## 2. Non-functional requirements
 
@@ -109,6 +116,12 @@ This document is the authoritative source of truth for what the implementation m
 - **NFR-2.4.2** Browser smoke E2E specs live under `tests/e2e/` and run with `bunx playwright test` against `bun run dev`.
 - **NFR-2.4.3** E2E coverage minimum: every route loads (page-load + hard-refresh deep link), hero copy renders verbatim on `/`, all three social links resolve on `/` and `/about`, theme toggle cycles and persists across reload, portrait image renders on `/about`, footer renders on every route, SPA fallback handles unknown paths.
 - **NFR-2.4.4** A fresh machine or CI worker can fully recreate the test environment with `bun install && bun run setup:browsers`; E2E must not depend on a pre-existing Playwright browser cache.
+
+### 2.5 Performance budgets
+- **NFR-2.5.1** Largest Contentful Paint (LCP) median ≤ 2500 ms on every audited route — Core Web Vitals "good" threshold; asserted at `error` level.
+- **NFR-2.5.2** Cumulative Layout Shift (CLS) median ≤ 0.1 on every audited route — Core Web Vitals "good" threshold; asserted at `error` level.
+- **NFR-2.5.3** Total Blocking Time (TBT) median ≤ 200 ms — asserted at `warn` level (lab-only signal; the production constraint is INP, which Lighthouse cannot measure synthetically).
+- **NFR-2.5.4** Lighthouse `categories:performance` median score ≥ 0.9 on every audited route; asserted at `error` level.
 
 ## 3. Growth path (designed-in, not built)
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,38 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3,
+      "url": [
+        "https://moster.dev/",
+        "https://moster.dev/about",
+        "https://moster.dev/articles"
+      ],
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "largest-contentful-paint": [
+          "error",
+          { "maxNumericValue": 2500, "aggregationMethod": "median" }
+        ],
+        "cumulative-layout-shift": [
+          "error",
+          { "maxNumericValue": 0.1, "aggregationMethod": "median" }
+        ],
+        "total-blocking-time": [
+          "warn",
+          { "maxNumericValue": 200, "aggregationMethod": "median" }
+        ],
+        "categories:performance": [
+          "error",
+          { "minScore": 0.9, "aggregationMethod": "median" }
+        ]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
Adds a Lighthouse CI job to the existing GitHub Actions workflow so production deploys and nightly scheduled runs audit moster.dev after deploy. Adds lighthouserc.json with three-run median assertions for LCP, CLS, TBT warnings, and the performance score while avoiding broad LHCI preset gates. Updates README, CLAUDE, requirements, architecture, and CI/CD feature specs to document the new performance monitoring behavior and CI coverage.