### PR TITLE
Update Wrangler action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run build
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Updates the deploy workflow to use cloudflare/wrangler-action@v4. This keeps the production deploy action current while preserving the existing Cloudflare token and account configuration.