### PR TITLE
Configure self-hosted LHCI uploads

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,15 @@
     "playwright@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": true,
+    "cloudflare@cloudflare": true
+  },
+  "extraKnownMarketplaces": {
+    "cloudflare": {
+      "source": {
+        "source": "github",
+        "repo": "cloudflare/skills"
+      }
+    }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,7 @@ jobs:
         with:
           configPath: ./lighthouserc.json
           uploadArtifacts: true
-          temporaryPublicStorage: true
+          serverBaseUrl: https://lhci.moster.dev
+          serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
+          basicAuthUsername: ${{ secrets.LHCI_BASIC_AUTH_USERNAME }}
+          basicAuthPassword: ${{ secrets.LHCI_BASIC_AUTH_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Current state: v2 redesign complete. Multi-page React 19 SPA via `react-router-d
 - `.github/CODEOWNERS` — requires `@jlvmoster` review on every PR.
 - `.github/dependabot.yml` — weekly grouped Bun-ecosystem updates (open-PR limit 5); source of `Bump …` PRs like #3.
 - `.github/workflows/ci.yml` — single workflow with `check` (PRs + pushes), `deploy` (push to `master`, needs `check`), and `lighthouse` (post-deploy + nightly `schedule`, needs `deploy`); canonical YAML in architecture §8.1.
-- `lighthouserc.json` — Lighthouse CI config at repo root; URL list (`/`, `/about`, `/articles`), `numberOfRuns: 3`, Core Web Vitals assertions with `aggregationMethod: "median"`, `temporary-public-storage` upload target. See `docs/specs/features/lighthouse-ci.md`.
+- `lighthouserc.json` — Lighthouse CI config at repo root; URL list (`/`, `/about`, `/articles`), `numberOfRuns: 3`, Core Web Vitals assertions with `aggregationMethod: "median"`, self-hosted LHCI Server upload target. See `docs/specs/features/lighthouse-ci.md`.
 - `wrangler.toml`, `src/worker.ts` — Cloudflare Workers + Static Assets config and pass-through fetch handler.
 - `playwright.config.ts`, `playwright.built.config.ts`, `playwright.production.config.ts` — browser E2E targets for dev server, built artifact, and production acceptance checks.
 - `worker-configuration.d.ts` — _(generated, gitignored)_ Worker runtime types, refreshed by `bunx wrangler types`.
@@ -125,7 +125,7 @@ Current state: v2 redesign complete. Multi-page React 19 SPA via `react-router-d
 - **Interactive verification during a task:** use the `mcp__plugin_playwright_playwright__*` MCP tools to drive a browser ad-hoc rather than writing throwaway specs. Per the global rule, UI changes must be exercised in a browser before being reported as complete.
 
 ## Agents and skills
-Plugins enabled in `.claude/settings.json`: `frontend-design`, `playwright`, `typescript-lsp`, `claude-md-management`, `skill-creator`, `superpowers`.
+Plugins enabled in `.claude/settings.json`: official marketplace plugins `claude-md-management`, `frontend-design`, `playwright`, `skill-creator`, `superpowers`, `typescript-lsp`; plus `cloudflare@cloudflare` from the `cloudflare/skills` marketplace, matching Cloudflare's agent setup prompt.
 
 Built-in subagents to lean on:
 - **`Explore`** — locating code under `src/` or facts in `docs/specs/requirements.md`.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Production deploys run automatically on push to `master`:
 
 1. `check` job: `bun install --frozen-lockfile`, `setup:browsers`, `check`, `build`, `bun test`, `bunx playwright test`, `bun run test:e2e:built`.
 2. `deploy` job (depends on `check`): builds and ships `dist/` via `cloudflare/wrangler-action@v3`.
-3. `lighthouse` job (depends on `deploy`, also runs on a nightly `schedule` cron): asserts Core Web Vitals budgets against `https://moster.dev` via `treosh/lighthouse-ci-action@v12` using thresholds in `lighthouserc.json`. Not a PR merge gate; failures alert rather than block.
+3. `lighthouse` job (depends on `deploy`, also runs on a nightly `schedule` cron): asserts Core Web Vitals budgets against `https://moster.dev` via `treosh/lighthouse-ci-action@v12` using thresholds in `lighthouserc.json`, then uploads results to the self-hosted LHCI Server at `https://lhci.moster.dev`. Not a PR merge gate; failures alert rather than block.
 
 Cloudflare credentials live as GitHub Actions secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and are never committed. `bun run deploy` from a developer machine is supported as a break-glass path but is not the source of truth.
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -531,7 +531,10 @@ jobs:
         with:
           configPath: ./lighthouserc.json
           uploadArtifacts: true
-          temporaryPublicStorage: true
+          serverBaseUrl: https://lhci.moster.dev
+          serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
+          basicAuthUsername: ${{ secrets.LHCI_BASIC_AUTH_USERNAME }}
+          basicAuthPassword: ${{ secrets.LHCI_BASIC_AUTH_PASSWORD }}
 ```
 
 The workflow scopes `GITHUB_TOKEN` to `contents: read`, which is enough for checkout while leaving deploy authentication to Cloudflare secrets. The `check` job order matches the fresh-machine bootstrap in `features/tooling.md`. The cache keys include `hashFiles('bun.lock')`, so dependency or Playwright-version changes naturally create fresh caches. `setup:browsers` still runs after cache restore for the same reason §NFR-2.4.4 calls it out: do not depend on a pre-existing Playwright cache being complete or warm. `--frozen-lockfile` ensures PRs that touch dependencies also commit `bun.lock`.
@@ -569,8 +572,8 @@ Requirements §1.8 adds a third job, `lighthouse`, to the same `ci.yml`. It runs
 
 - **Post-deploy, not PR-gating.** Lighthouse runs on a shared GitHub runner are noisy; per-PR enforcement would block merges on jitter rather than real regressions. Running against the *deployed* site, against absolute Core Web Vitals cutoffs, with N=3 runs and `aggregationMethod: "median"`, gives a trustworthy signal at the cost of detecting regressions slightly after they ship. Recovery is a roll-back, not a merge block.
 - **One workflow, three jobs.** `check` and `deploy` are unchanged; `lighthouse` chains off `deploy` via `needs:`. The `if: always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')` guard makes the job fire on both `push` (after a successful deploy) and `schedule` (where `deploy` is skipped). The `check` job adds `if: github.event_name != 'schedule'` so the cron run does not re-run the full test suite.
-- **`treosh/lighthouse-ci-action` over rolling our own.** The official `GoogleChrome/lighthouse-ci` repo points readers at this community action; it's a thin wrapper around `@lhci/cli` with GH-native artifact and public-storage upload paths.
-- **No LHCI Server.** Historical diffs and a status-check integration require self-hosting Postgres + a server. For a personal site, the `temporary-public-storage` link in the workflow log plus the uploaded HTML artifact are enough; this stays consistent with §NFR-2.2.2 (no paid third-party services for v1).
+- **`treosh/lighthouse-ci-action` over rolling our own.** The official `GoogleChrome/lighthouse-ci` repo points readers at this community action; it's a thin wrapper around `@lhci/cli` with GH-native artifact and LHCI Server upload paths.
+- **Self-hosted LHCI Server.** Uploading to `https://lhci.moster.dev` gives historical trend data for the live site while keeping raw HTML reports attached to each workflow run. The build token and basic-auth credentials stay in GitHub Actions secrets (§FR-1.8.6), so no LHCI credentials are committed.
 
 **Cost.** One ubuntu-latest runner × ~5 min × (push frequency + nightly) is well under the GitHub Actions free tier ceiling per §NFR-2.2.3.
 

--- a/docs/specs/features/lighthouse-ci.md
+++ b/docs/specs/features/lighthouse-ci.md
@@ -8,7 +8,8 @@ Post-deploy performance monitoring against `https://moster.dev` that asserts Cor
 - §FR-1.8.2 — Budgets live in committed `lighthouserc.json`; assertions run via `@lhci/cli` invoked through `treosh/lighthouse-ci-action`.
 - §FR-1.8.3 — Triggered on push to `master` (after `deploy`) and on a daily `schedule:` cron. Not a PR merge gate.
 - §FR-1.8.4 — `numberOfRuns: 3` with `aggregationMethod: "median"` on every assertion.
-- §FR-1.8.5 — Reports uploaded to Google's temporary public storage and saved as a GitHub Actions artifact.
+- §FR-1.8.5 — Reports uploaded to the self-hosted LHCI Server at `https://lhci.moster.dev` and saved as GitHub Actions artifacts.
+- §FR-1.8.6 — LHCI Server upload credentials live only in GitHub Actions secrets.
 - §NFR-2.5.1 — LCP median ≤ 2500 ms (`error`).
 - §NFR-2.5.2 — CLS median ≤ 0.1 (`error`).
 - §NFR-2.5.3 — TBT median ≤ 200 ms (`warn`).
@@ -33,17 +34,17 @@ Post-deploy performance monitoring against `https://moster.dev` that asserts Cor
   - `warn` on TBT — TBT is a lab-only proxy for the production INP signal; a failed budget is informational.
 - **Assertion scope:** `lighthouserc.json` intentionally omits LHCI assertion presets such as `lighthouse:no-pwa`; only the explicit Core Web Vitals and performance-score budgets above are enforced. Broader accessibility, SEO, best-practices, or image-optimization audits should be added as separate requirements when they become intentional gates.
 - **Deploy → measurement gap:** the `lighthouse` job sleeps 30 s on the `push` path (`if: github.event_name == 'push'`) so Cloudflare's global propagation completes before the audit. The schedule path skips the sleep because production is already live.
-- **Report surfacing:** `temporaryPublicStorage: true` posts a shareable link in the workflow log (Google-hosted, no auth, no history). `uploadArtifacts: true` also stashes the raw HTML report as a workflow artifact. No LHCI Server is provisioned for v1 (§FR-1.8.5).
+- **Report surfacing:** `serverBaseUrl: https://lhci.moster.dev` uploads each run to the self-hosted LHCI Server for historical comparison, using `LHCI_BUILD_TOKEN` plus optional basic-auth credentials from GitHub Actions secrets (§FR-1.8.5, §FR-1.8.6). `uploadArtifacts: true` also stashes the raw HTML reports as workflow artifacts.
 - **Failure semantics:** a Lighthouse assertion failure marks the workflow run red and emails the repo owner via GitHub's default notifications. The site stays on the just-deployed revision; rolling back is a manual decision based on the report link.
 - **Cost:** one ubuntu-latest runner × ~5 min × (push-frequency + nightly) stays well under the free-tier 2,000 min/month even with daily runs.
 
 ## Test plan
-- **First-run smoke:** merge this feature to `master`, watch CI; confirm `lighthouse` job runs after `deploy`, posts a `temporary-public-storage` URL in the log, and uploads an artifact.
+- **First-run smoke:** merge this feature to `master`, watch CI; confirm `lighthouse` job runs after `deploy`, uploads the run to `https://lhci.moster.dev`, and uploads an artifact.
 - **Scheduled-run smoke:** on the next nightly cron firing, confirm a workflow run appears with only `lighthouse` executed (no `check`, no `deploy`).
 - **Failing-budget rehearsal:** temporarily lower `largest-contentful-paint.maxNumericValue` to `100` in `lighthouserc.json` on a throwaway branch, push to `master`, confirm the `lighthouse` job fails red and the linked report shows the assertion. Revert.
 - **PR isolation:** open a PR; confirm `lighthouse` does not run and is not listed as a required check in branch protection.
 
 ## Open questions
 - Add a separate **mobile** preset matrix entry? Deferred — desktop-first audience, and a second preset doubles audit time.
-- Move to a self-hosted LHCI Server (`serverBaseUrl` + `serverToken`) for historical diffing? Deferred per §FR-1.8.5 — not worth the Postgres + Heroku/Docker footprint for a personal site.
+- Add LHCI GitHub status checks or PR comments from the self-hosted server? Deferred — the job remains post-deploy and non-PR-gating per §FR-1.8.3.
 - Add a `budget.json` for byte-size budgets (JS/CSS/images)? Deferred until a regression actually demands it; the assertion budgets above already catch LCP regressions caused by oversized assets.

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -90,7 +90,8 @@ This document is the authoritative source of truth for what the implementation m
 - **FR-1.8.2** Lighthouse thresholds live in a committed `lighthouserc.json` at the repo root and are asserted via `@lhci/cli` invoked through `treosh/lighthouse-ci-action`.
 - **FR-1.8.3** The Lighthouse job runs after the `deploy` job on push to `master`, and also on a daily `schedule` trigger so regressions surface even when no code changes have shipped. It is not a PR merge gate.
 - **FR-1.8.4** Each Lighthouse run executes ≥ 3 audits per URL and asserts against the median, to absorb runner variance.
-- **FR-1.8.5** Each run uploads its HTML report to Google's temporary public storage (link in workflow logs) and as a GitHub Actions artifact; no self-hosted LHCI Server is introduced for v1.
+- **FR-1.8.5** Each run uploads its results to the self-hosted LHCI Server at `https://lhci.moster.dev` for historical reporting and also saves the raw reports as GitHub Actions artifacts.
+- **FR-1.8.6** LHCI Server upload credentials are stored only as GitHub Actions secrets (`LHCI_BUILD_TOKEN`, `LHCI_BASIC_AUTH_USERNAME`, `LHCI_BASIC_AUTH_PASSWORD`) and are never committed to the repository.
 
 ## 2. Non-functional requirements
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -32,7 +32,8 @@
       }
     },
     "upload": {
-      "target": "temporary-public-storage"
+      "target": "lhci",
+      "serverBaseUrl": "https://lhci.moster.dev"
     }
   }
 }


### PR DESCRIPTION
Switch Lighthouse CI uploads from temporary public storage to the self-hosted LHCI server at https://lhci.moster.dev using GitHub Actions secrets for the build token and basic auth. Update the authoritative requirements, feature spec, architecture notes, README, and Claude project guide to match the new LHCI server behavior. Also register the Cloudflare marketplace plugin in Claude settings so Cloudflare workflows are available in this repo.\n\nValidation: pre-commit ran wrangler types, biome check, and tsc --noEmit.