### PR TITLE
Run Lighthouse CI schedule weekly on Sundays at 06:00 EST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [master]
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 11 * * 0'
 permissions:
   contents: read
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Current state: v2 redesign complete. Multi-page React 19 SPA via `react-router-d
 - `.claude/settings.json` — enabled plugins and Bash permission allowlist.
 - `.github/CODEOWNERS` — requires `@jlvmoster` review on every PR.
 - `.github/dependabot.yml` — weekly grouped Bun-ecosystem updates (open-PR limit 5); source of `Bump …` PRs like #3.
-- `.github/workflows/ci.yml` — single workflow with `check` (PRs + pushes), `deploy` (push to `master`, needs `check`), and `lighthouse` (post-deploy + nightly `schedule`, needs `deploy`); canonical YAML in architecture §8.1.
+- `.github/workflows/ci.yml` — single workflow with `check` (PRs + pushes), `deploy` (push to `master`, needs `check`), and `lighthouse` (post-deploy + weekly `schedule`, needs `deploy`); canonical YAML in architecture §8.1.
 - `lighthouserc.json` — Lighthouse CI config at repo root; URL list (`/`, `/about`, `/articles`), `numberOfRuns: 3`, Core Web Vitals assertions with `aggregationMethod: "median"`, self-hosted LHCI Server upload target. See `docs/specs/features/lighthouse-ci.md`.
 - `wrangler.toml`, `src/worker.ts` — Cloudflare Workers + Static Assets config and pass-through fetch handler.
 - `playwright.config.ts`, `playwright.built.config.ts`, `playwright.production.config.ts` — browser E2E targets for dev server, built artifact, and production acceptance checks.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Jalo Moster's personal website — a multi-page React SPA deployed to Cloudflare
 - **Hosting:** Cloudflare Workers + Static Assets (not Pages) on `moster.dev`. SPA fallback handles deep-link refreshes.
 - **Lint / format:** Biome. **Types:** TypeScript strict mode + generated Worker types.
 - **Testing:** `bun test` for units, `@playwright/test` for browser E2E.
-- **CI/CD:** GitHub Actions — `check` on every PR/push, `deploy` on push to `master` via `cloudflare/wrangler-action@v3`, and `lighthouse` post-deploy + nightly via `treosh/lighthouse-ci-action@v12`.
+- **CI/CD:** GitHub Actions — `check` on every PR/push, `deploy` on push to `master` via `cloudflare/wrangler-action@v3`, and `lighthouse` post-deploy + weekly via `treosh/lighthouse-ci-action@v12`.
 
 No Vite, webpack, esbuild, Next.js, MDX, or third-party UI component libraries — the Bun HTML bundler is the entire build pipeline. `react-router-dom`, `clsx`, and `@tailwindcss/typography` are utilities/plugins and are permitted.
 
@@ -110,7 +110,7 @@ Production deploys run automatically on push to `master`:
 
 1. `check` job: `bun install --frozen-lockfile`, `setup:browsers`, `check`, `build`, `bun test`, `bunx playwright test`, `bun run test:e2e:built`.
 2. `deploy` job (depends on `check`): builds and ships `dist/` via `cloudflare/wrangler-action@v3`.
-3. `lighthouse` job (depends on `deploy`, also runs on a nightly `schedule` cron): asserts Core Web Vitals budgets against `https://moster.dev` via `treosh/lighthouse-ci-action@v12` using thresholds in `lighthouserc.json`, then uploads results to the self-hosted LHCI Server at `https://lhci.moster.dev`. Not a PR merge gate; failures alert rather than block.
+3. `lighthouse` job (depends on `deploy`, also runs on a weekly `schedule` cron — Sundays at 06:00 EST / 11:00 UTC): asserts Core Web Vitals budgets against `https://moster.dev` via `treosh/lighthouse-ci-action@v12` using thresholds in `lighthouserc.json`, then uploads results to the self-hosted LHCI Server at `https://lhci.moster.dev`. Not a PR merge gate; failures alert rather than block.
 
 Cloudflare credentials live as GitHub Actions secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) and are never committed. `bun run deploy` from a developer machine is supported as a break-glass path but is not the source of truth.
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -463,7 +463,7 @@ on:
   push:
     branches: [master]
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 11 * * 0'
 permissions:
   contents: read
 jobs:
@@ -566,7 +566,7 @@ Branch protection should require `check` before merge. The deploy job is not a p
 
 ### 8.5 Post-deploy Lighthouse CI
 
-Requirements §1.8 adds a third job, `lighthouse`, to the same `ci.yml`. It runs `@lhci/cli` via [`treosh/lighthouse-ci-action@v12`](https://github.com/treosh/lighthouse-ci-action) against `https://moster.dev` after every production deploy and on a daily `schedule:` cron, asserting Core Web Vitals budgets defined in `lighthouserc.json` at the repo root. The per-feature implementation spec is at [features/lighthouse-ci.md](features/lighthouse-ci.md).
+Requirements §1.8 adds a third job, `lighthouse`, to the same `ci.yml`. It runs `@lhci/cli` via [`treosh/lighthouse-ci-action@v12`](https://github.com/treosh/lighthouse-ci-action) against `https://moster.dev` after every production deploy and on a weekly `schedule:` cron, asserting Core Web Vitals budgets defined in `lighthouserc.json` at the repo root. The per-feature implementation spec is at [features/lighthouse-ci.md](features/lighthouse-ci.md).
 
 **Why this shape:**
 
@@ -575,7 +575,7 @@ Requirements §1.8 adds a third job, `lighthouse`, to the same `ci.yml`. It runs
 - **`treosh/lighthouse-ci-action` over rolling our own.** The official `GoogleChrome/lighthouse-ci` repo points readers at this community action; it's a thin wrapper around `@lhci/cli` with GH-native artifact and LHCI Server upload paths.
 - **Self-hosted LHCI Server.** Uploading to `https://lhci.moster.dev` gives historical trend data for the live site while keeping raw HTML reports attached to each workflow run. The build token and basic-auth credentials stay in GitHub Actions secrets (§FR-1.8.6), so no LHCI credentials are committed.
 
-**Cost.** One ubuntu-latest runner × ~5 min × (push frequency + nightly) is well under the GitHub Actions free tier ceiling per §NFR-2.2.3.
+**Cost.** One ubuntu-latest runner × ~5 min × (push frequency + weekly) is well under the GitHub Actions free tier ceiling per §NFR-2.2.3.
 
 ## 9. Sources
 

--- a/docs/specs/features/ci-cd.md
+++ b/docs/specs/features/ci-cd.md
@@ -19,12 +19,12 @@ Automated CI on every PR and push to `master`, and automated production deploys 
 
 ## Behavior & edge cases
 - **Workflow (`.github/workflows/ci.yml`):**
-  - Triggers: `pull_request` against `master`, `push` to `master`, and a `schedule: '0 7 * * *'` cron that fires only the `lighthouse` job (see `features/lighthouse-ci.md`).
+  - Triggers: `pull_request` against `master`, `push` to `master`, and a `schedule: '0 11 * * 0'` cron (Sundays at 06:00 EST / 11:00 UTC) that fires only the `lighthouse` job (see `features/lighthouse-ci.md`).
   - `check` job runs on `ubuntu-latest` and is gated with `if: github.event_name != 'schedule'` so cron runs do not re-execute the suite.
   - `check` steps in order: `actions/checkout@v6` → `actions/setup-node@v6` (node 22) → `oven-sh/setup-bun@v2` → restore Bun package cache → restore Playwright browser cache → `bun install --frozen-lockfile` → `bun run setup:browsers` → `bun run check` → `bun run build` → `bun test` → `bunx playwright test` → `bunx playwright test -c playwright.built.config.ts`.
   - `deploy` job has `needs: check` and only runs when `github.event_name == 'push' && github.ref == 'refs/heads/master'`.
   - `deploy` steps: `actions/checkout@v6` → `actions/setup-node@v6` (node 22) → `oven-sh/setup-bun@v2` → restore Bun package cache → `bun install --frozen-lockfile` → `bun run build` → `cloudflare/wrangler-action@v3`.
-  - `lighthouse` job (`needs: deploy`, `if: always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')`) runs post-deploy and on the daily cron; see `features/lighthouse-ci.md` for behavior.
+  - `lighthouse` job (`needs: deploy`, `if: always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')`) runs post-deploy and on the weekly cron; see `features/lighthouse-ci.md` for behavior.
   - The Wrangler action receives `apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}` and `accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}`.
   - `--frozen-lockfile` enforces that PRs touching dependencies update `bun.lock`.
   - Cache Bun packages with `actions/cache@v5`, path `~/.bun/install/cache`, key `bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}`.

--- a/docs/specs/features/lighthouse-ci.md
+++ b/docs/specs/features/lighthouse-ci.md
@@ -1,12 +1,12 @@
 # Lighthouse CI — Implementation Spec
 
 ## Goal
-Post-deploy performance monitoring against `https://moster.dev` that asserts Core Web Vitals budgets on every push to `master` and on a nightly schedule. Failures alert; they do not gate PR merges.
+Post-deploy performance monitoring against `https://moster.dev` that asserts Core Web Vitals budgets on every push to `master` and on a weekly schedule. Failures alert; they do not gate PR merges.
 
 ## Requirements covered
 - §FR-1.8.1 — Lighthouse runs against the live site on a representative set of routes after every production deploy.
 - §FR-1.8.2 — Budgets live in committed `lighthouserc.json`; assertions run via `@lhci/cli` invoked through `treosh/lighthouse-ci-action`.
-- §FR-1.8.3 — Triggered on push to `master` (after `deploy`) and on a daily `schedule:` cron. Not a PR merge gate.
+- §FR-1.8.3 — Triggered on push to `master` (after `deploy`) and on a weekly `schedule:` cron. Not a PR merge gate.
 - §FR-1.8.4 — `numberOfRuns: 3` with `aggregationMethod: "median"` on every assertion.
 - §FR-1.8.5 — Reports uploaded to the self-hosted LHCI Server at `https://lhci.moster.dev` and saved as GitHub Actions artifacts.
 - §FR-1.8.6 — LHCI Server upload credentials live only in GitHub Actions secrets.
@@ -14,7 +14,7 @@ Post-deploy performance monitoring against `https://moster.dev` that asserts Cor
 - §NFR-2.5.2 — CLS median ≤ 0.1 (`error`).
 - §NFR-2.5.3 — TBT median ≤ 200 ms (`warn`).
 - §NFR-2.5.4 — Performance category median ≥ 0.9 (`error`).
-- §NFR-2.2.3 — Stays on GitHub Actions' free tier (one runner, ~5 minutes, runs only on master + nightly).
+- §NFR-2.2.3 — Stays on GitHub Actions' free tier (one runner, ~5 minutes, runs only on master + weekly).
 
 ## File layout
 - `lighthouserc.json` — repo root, consumed by the action via `configPath`. Holds the URL list, run count, assertion thresholds, and upload target.
@@ -24,7 +24,7 @@ Post-deploy performance monitoring against `https://moster.dev` that asserts Cor
 ## Behavior & edge cases
 - **Trigger surface:**
   - `push` to `master` → `check` → `deploy` → `lighthouse` (in that order, via `needs:` chain).
-  - `schedule` (`0 7 * * *` UTC) → only `lighthouse` runs; `check` is skipped via `if: github.event_name != 'schedule'`, `deploy` is skipped by its existing event-name guard, and `lighthouse` evaluates because of `always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')`.
+  - `schedule` (`0 11 * * 0` — Sundays at 06:00 EST / 11:00 UTC) → only `lighthouse` runs; `check` is skipped via `if: github.event_name != 'schedule'`, `deploy` is skipped by its existing event-name guard, and `lighthouse` evaluates because of `always() && (needs.deploy.result == 'success' || github.event_name == 'schedule')`.
   - `pull_request` → `check` runs; `deploy` and `lighthouse` are skipped. Lighthouse never gates a PR.
 - **Audited routes (in `lighthouserc.json`):** `/`, `/about`, `/articles`. Keeps audit time bounded (~5 min for 3 URLs × 3 runs) and covers the three structurally distinct pages (Home hero + avatar scaling, image-heavy About, list page). Adding `/projects` and `/uses` is a one-line edit when their performance becomes a concern.
 - **Run count and aggregation:** `numberOfRuns: 3` with `aggregationMethod: "median"` on each assertion. Single-run Lighthouse on shared GH runners commonly swings ±500 ms on LCP; the median across three runs absorbs that.
@@ -36,11 +36,11 @@ Post-deploy performance monitoring against `https://moster.dev` that asserts Cor
 - **Deploy → measurement gap:** the `lighthouse` job sleeps 30 s on the `push` path (`if: github.event_name == 'push'`) so Cloudflare's global propagation completes before the audit. The schedule path skips the sleep because production is already live.
 - **Report surfacing:** `serverBaseUrl: https://lhci.moster.dev` uploads each run to the self-hosted LHCI Server for historical comparison, using `LHCI_BUILD_TOKEN` plus optional basic-auth credentials from GitHub Actions secrets (§FR-1.8.5, §FR-1.8.6). `uploadArtifacts: true` also stashes the raw HTML reports as workflow artifacts.
 - **Failure semantics:** a Lighthouse assertion failure marks the workflow run red and emails the repo owner via GitHub's default notifications. The site stays on the just-deployed revision; rolling back is a manual decision based on the report link.
-- **Cost:** one ubuntu-latest runner × ~5 min × (push-frequency + nightly) stays well under the free-tier 2,000 min/month even with daily runs.
+- **Cost:** one ubuntu-latest runner × ~5 min × (push-frequency + weekly) stays well under the free-tier 2,000 min/month.
 
 ## Test plan
 - **First-run smoke:** merge this feature to `master`, watch CI; confirm `lighthouse` job runs after `deploy`, uploads the run to `https://lhci.moster.dev`, and uploads an artifact.
-- **Scheduled-run smoke:** on the next nightly cron firing, confirm a workflow run appears with only `lighthouse` executed (no `check`, no `deploy`).
+- **Scheduled-run smoke:** on the next weekly cron firing, confirm a workflow run appears with only `lighthouse` executed (no `check`, no `deploy`).
 - **Failing-budget rehearsal:** temporarily lower `largest-contentful-paint.maxNumericValue` to `100` in `lighthouserc.json` on a throwaway branch, push to `master`, confirm the `lighthouse` job fails red and the linked report shows the assertion. Revert.
 - **PR isolation:** open a PR; confirm `lighthouse` does not run and is not listed as a required check in branch protection.
 

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -88,7 +88,7 @@ This document is the authoritative source of truth for what the implementation m
 ### 1.8 Performance monitoring
 - **FR-1.8.1** Production deploys are followed by an automated Lighthouse CI run against the live site that measures Core Web Vitals (LCP, CLS) and total blocking time on a representative set of routes.
 - **FR-1.8.2** Lighthouse thresholds live in a committed `lighthouserc.json` at the repo root and are asserted via `@lhci/cli` invoked through `treosh/lighthouse-ci-action`.
-- **FR-1.8.3** The Lighthouse job runs after the `deploy` job on push to `master`, and also on a daily `schedule` trigger so regressions surface even when no code changes have shipped. It is not a PR merge gate.
+- **FR-1.8.3** The Lighthouse job runs after the `deploy` job on push to `master`, and also on a weekly `schedule` trigger so regressions surface even when no code changes have shipped. It is not a PR merge gate.
 - **FR-1.8.4** Each Lighthouse run executes ≥ 3 audits per URL and asserts against the median, to absorb runner variance.
 - **FR-1.8.5** Each run uploads its results to the self-hosted LHCI Server at `https://lhci.moster.dev` for historical reporting and also saves the raw reports as GitHub Actions artifacts.
 - **FR-1.8.6** LHCI Server upload credentials are stored only as GitHub Actions secrets (`LHCI_BUILD_TOKEN`, `LHCI_BASIC_AUTH_USERNAME`, `LHCI_BASIC_AUTH_PASSWORD`) and are never committed to the repository.


### PR DESCRIPTION
The Lighthouse `schedule` cron in `ci.yml` was firing **daily** (`0 7 * * *`, 07:00 UTC); this changes it to `0 11 * * 0` so the standalone audit runs **once a week, every Sunday at 06:00 EST (11:00 UTC)**. The remaining six files (`requirements.md`, `architecture.md`, `ci-cd.md`, `lighthouse-ci.md`, `README.md`, `CLAUDE.md`) are doc/spec updates that swap the old "daily/nightly" wording for "weekly" and record the new Sunday EST/UTC trigger so the specs match the workflow. No job-gating logic changed — `check` still skips on schedule, `deploy` stays push-to-master only, and `lighthouse` still fires on deploy-success or schedule. Note: GitHub cron is fixed-UTC and ignores DST, so this lands at 6 AM during EST and 7 AM during EDT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)